### PR TITLE
Fix bug with enumerating devices

### DIFF
--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileList.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileList.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright Â© 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -22,6 +22,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
@@ -85,7 +86,7 @@ namespace MonoLibUsb.Profile
             newList.mList.RemoveAll(FindDiscoveredFn);
             newList.Close();
 
-            foreach (MonoUsbProfile deviceProfile in mList)
+            foreach (MonoUsbProfile deviceProfile in mList.ToList())
             {
                 if (!deviceProfile.mDiscovered)
                 {


### PR DESCRIPTION
Addresses #19.

Resolves an issue where an `InvalidOperationException: Collection was modified; enumeration operation may not execute.` is thrown when USB devices are removed (and possibly added) as they're being enumerated on a Linux platform using `LinuxDeviceNotifier` (`DeviceListPolling`).

Currently I've got a test set up where I use a .NET Core application running on a Raspberry Pi to send messages to a microcontroller over USB to toggle a relay on and off. This runs in a continuous loop and while it's running, I try unplugging the USB cable between the RPi and the device. Specifically, I follow this procedure:

1. Build and publish .NET application on a Windows 7 64-bit machine (`dotnet publish -c Release -r linux-arm -p:SolutionDir=../.. -o usb_device_test`),
2. Copy the folder over SSH to a Raspberry Pi 3 connected to the local intranet (`scp -r usb_device_test me@$(find-pi.bat):~`).
3. Ensure the microcontroller is connected via USB to the RPi. 
4. SSH into the RPi, cd into `usb_device_test` and try executing the application with root privileges (`sudo ./MyCompany.MyProduct.FunctionalTest`).
5. Allow the application to launch and let it send USB messages to the device for a while.
6. Unplug the USB cable from the RPi.
7. Wait for errors to display showing USB communication failed, as expected. Wait a little longer to see if `InvalidOperationException` gets thrown.

I've tested the latest code on master both with and without this fix. Without this fix, I find an `InvalidOperationException` being thrown almost every time I disconnect the device. With the fix applied, I've performed this test 10 times in succession without an exception being thrown.

Before merging this PR, you might want to perform similar tests on your own devices.