### PR TITLE
Fix NuGet packaging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,5 @@ build_script:
   - dotnet pack stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
 
 artifacts:
-  - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.10-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
-  - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.10-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+  - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.10-*.nupkg
+  - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.10-*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,3 +11,11 @@ build_script:
 artifacts:
   - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.10-*.nupkg
   - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.10-*.nupkg
+
+deploy:
+  provider: NuGet
+  on:
+    branch: master
+  api_key:
+    secure: EE+SrSChcQWBbROVoNVqVmUNJLh7humtKClEyJoc05VUbV5gQWbhjndwQFuiu2kz
+  skip_symbols: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,13 @@
 image: Visual Studio 2017
 
 build_script:
-  - dotnet restore stage\LibUsbDotNet\LibUsbDotNet.csproj --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - dotnet restore stage\LibUsb.Common\LibUsb.Common.csproj /p:VersionSuffix=r%APPVEYOR_BUILD_NUMBER%
+  - dotnet restore stage\LibUsbDotNet\LibUsbDotNet.csproj /p:VersionSuffix=r%APPVEYOR_BUILD_NUMBER%
   - dotnet build stage\LibUsb.Common\LibUsb.Common.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - dotnet pack stage\LibUsb.Common\LibUsb.Common.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - dotnet build stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - dotnet pack stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
 
 artifacts:
-  - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.9-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
-  - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.9-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+  - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.10-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+  - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.10-r$($env:APPVEYOR_BUILD_NUMBER).nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
 image: Visual Studio 2017
 
 build_script:
-  - dotnet restore stage\LibUsbDotNet\LibUsbDotNet.csproj
-  - dotnet build stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release
+  - dotnet restore stage\LibUsbDotNet\LibUsbDotNet.csproj --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - dotnet build stage\LibUsb.Common\LibUsb.Common.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - dotnet pack stage\LibUsb.Common\LibUsb.Common.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - dotnet build stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - dotnet pack stage\LibUsbDotNet\LibUsbDotNet.csproj /p:Configuration=Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
 
-on_success:
-  - ps: Push-AppVeyorArtifact stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.9-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+artifacts:
+  - path: stage\LibUsbDotNet\bin\Release\LibUsbDotNet.2.2.9-r$($env:APPVEYOR_BUILD_NUMBER).nupkg
+  - path: stage\LibUsb.Common\bin\Release\LibUsb.Common.2.2.9-r$($env:APPVEYOR_BUILD_NUMBER).nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ deploy:
   on:
     branch: master
   api_key:
-    secure: EE+SrSChcQWBbROVoNVqVmUNJLh7humtKClEyJoc05VUbV5gQWbhjndwQFuiu2kz
+    secure: 0wE8RLp9KRRDy9yQG29TCLGJ1+2uhCC6vMEinDSPVU57txXoQBVGK9jkpED+zrib
   skip_symbols: true

--- a/stage/LibUsb.Common/LibUsb.Common.csproj
+++ b/stage/LibUsb.Common/LibUsb.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <VersionPrefix>2.2.10</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>.NET C# USB library for WinUSB, LibUsb-Win32, and libusb-1.0. Using the common device classes, applications work with all operating systems and drivers without modification. Lots of example code. Open source software at sourceforge.net.</Description>
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
-    <VersionPrefix>2.2.9</VersionPrefix>
+    <VersionPrefix>2.2.10</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>


### PR DESCRIPTION
- Set the AppVeyor build number to 100 so we are OK with semver
- Publish both LibUsb.Common as well as LibUsbDotNet
- Automatically push to NuGet when master is updated

Fixes #14 #25 