### PR TITLE
Allow DeviceNotifyEventArgs to be subclassed in client code

### DIFF
--- a/stage/LibUsbDotNet/DeviceNotify/DeviceNotifyEventArgs.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/DeviceNotifyEventArgs.cs
@@ -29,23 +29,13 @@ namespace LibUsbDotNet.DeviceNotify
     /// </summary> 
     public abstract class DeviceNotifyEventArgs : EventArgs
     {
-        internal IUsbDeviceNotifyInfo mDevice;
-        internal DeviceType mDeviceType;
-        internal EventType mEventType;
-        internal object mObject;
-        internal IPortNotifyInfo mPort;
-        internal IVolumeNotifyInfo mVolume;
-
         /// <summary>
         /// Gets the <see cref="VolumeNotifyInfo"/> class.
         /// </summary>
         /// <remarks>
         /// This value is null if the <see cref="DeviceNotifyEventArgs.DeviceType"/> is not set to <see cref="DeviceNotify.DeviceType.Volume"/>
         /// </remarks>
-        public IVolumeNotifyInfo Volume
-        {
-            get { return mVolume; }
-        }
+        public IVolumeNotifyInfo Volume { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="PortNotifyInfo"/> class.
@@ -53,10 +43,7 @@ namespace LibUsbDotNet.DeviceNotify
         /// <remarks>
         /// This value is null if the <see cref="DeviceNotifyEventArgs.DeviceType"/> is not set to <see cref="DeviceNotify.DeviceType.Port"/>
         /// </remarks>
-        public IPortNotifyInfo Port
-        {
-            get { return mPort; }
-        }
+        public IPortNotifyInfo Port { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="UsbDeviceNotifyInfo"/> class.
@@ -64,26 +51,16 @@ namespace LibUsbDotNet.DeviceNotify
         /// <remarks>
         /// This value is null if the <see cref="DeviceNotifyEventArgs.DeviceType"/> is not set to <see cref="DeviceNotify.DeviceType.DeviceInterface"/>
         /// </remarks>
-        public IUsbDeviceNotifyInfo Device
-        {
-            get { return mDevice; }
-        }
-
+        public IUsbDeviceNotifyInfo Device { get; protected set; }
         /// <summary>
         /// Gets the <see cref="EventType"/> for this notification.
         /// </summary>
-        public EventType EventType
-        {
-            get { return mEventType; }
-        }
+        public EventType EventType { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="DeviceType"/> for this notification.
         /// </summary>
-        public DeviceType DeviceType
-        {
-            get { return mDeviceType; }
-        }
+        public DeviceType DeviceType { get; protected set; }
 
         /// <summary>
         /// Gets the notification class as an object.
@@ -91,10 +68,7 @@ namespace LibUsbDotNet.DeviceNotify
         /// <remarks>
         /// This value is never null.
         /// </remarks>
-        public object Object
-        {
-            get { return mObject; }
-        }
+        public object Object { get; protected set; }
 
         ///<summary>
         ///Returns a <see cref="T:System.String"/> that represents the current <see cref="DeviceNotifyEventArgs"/>.
@@ -103,10 +77,6 @@ namespace LibUsbDotNet.DeviceNotify
         ///<returns>
         ///A <see cref="System.String"/> that represents the current <see cref="DeviceNotifyEventArgs"/>.
         ///</returns>
-        public override string ToString()
-        {
-            object[] o = {DeviceType, EventType, mObject.ToString()};
-            return string.Format("[DeviceType:{0}] [EventType:{1}] {2}", o);
-        }
+        public override string ToString() => $"[DeviceType:{DeviceType}] [EventType:{EventType}] {Object}";
     }
 }

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifyEventArgs.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifyEventArgs.cs
@@ -30,17 +30,17 @@ namespace LibUsbDotNet.DeviceNotify.Linux
     {
         internal LinuxDeviceNotifyEventArgs(LinuxDevItem linuxDevItem, DeviceType deviceType, EventType eventType)
         {
-            mEventType = eventType;
-            mDeviceType = deviceType;
-            switch (mDeviceType)
+            EventType = eventType;
+            DeviceType = deviceType;
+            switch (DeviceType)
             {
                 case DeviceType.Volume:
-                    throw new NotImplementedException(mDeviceType.ToString());
+                    throw new NotImplementedException(DeviceType.ToString());
                 case DeviceType.Port:
-                    throw new NotImplementedException(mDeviceType.ToString());
+                    throw new NotImplementedException(DeviceType.ToString());
                 case DeviceType.DeviceInterface:
-                    mDevice = new LinuxUsbDeviceNotifyInfo(linuxDevItem);
-                    mObject = mDevice;
+                    Device = new LinuxUsbDeviceNotifyInfo(linuxDevItem);
+                    Object = Device;
                     break;
             }
         }

--- a/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifyEventArgs.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifyEventArgs.cs
@@ -35,21 +35,21 @@ namespace LibUsbDotNet.DeviceNotify
         internal WindowsDeviceNotifyEventArgs(DevBroadcastHdr hdr, IntPtr ptrHdr, EventType eventType)
         {
             mBaseHdr = hdr;
-            mEventType = eventType;
-            mDeviceType = mBaseHdr.DeviceType;
-            switch (mDeviceType)
+            EventType = eventType;
+            DeviceType = mBaseHdr.DeviceType;
+            switch (DeviceType)
             {
                 case DeviceType.Volume:
-                    mVolume = new VolumeNotifyInfo(ptrHdr);
-                    mObject = mVolume;
+                    Volume = new VolumeNotifyInfo(ptrHdr);
+                    Object = Volume;
                     break;
                 case DeviceType.Port:
-                    mPort = new PortNotifyInfo(ptrHdr);
-                    mObject = mPort;
+                    Port = new PortNotifyInfo(ptrHdr);
+                    Object = Port;
                     break;
                 case DeviceType.DeviceInterface:
-                    mDevice = new UsbDeviceNotifyInfo(ptrHdr);
-                    mObject = mDevice;
+                    Device = new UsbDeviceNotifyInfo(ptrHdr);
+                    Object = Device;
                     break;
             }
         }


### PR DESCRIPTION
Addresses #18.

I've uploaded a package containing these changes to my company's private feed and it seems to work for my use case, but you might want to test these changes yourself before merging this PR.

In my case, I'm able to replace this:

```cs
public class PartialDeviceNotifyEventArgs : DeviceNotifyEventArgs
{
    public PartialDeviceNotifyEventArgs(EventType eventType, int vendorId, int productId)
    {
        var device = new InternalUsbDeviceNotifyInfo { IdVendor = vendorId, IdProduct = productId };
        var baseType = typeof(PartialDeviceNotifyEventArgs);
        const BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;

        baseType.GetField("mDevice", bindingFlags).SetValue(this, device);
        baseType.GetField("mEventType", bindingFlags).SetValue(this, eventType);
    }
    
    // ...
}
```
With this:

```cs
public class PartialDeviceNotifyEventArgs : DeviceNotifyEventArgs
{
    public PartialDeviceNotifyEventArgs(EventType eventType, int vendorId, int productId)
    {
        Device = new InternalUsbDeviceNotifyInfo { IdVendor = vendorId, IdProduct = productId };
        EventType = eventType;
    }

    // ...
}
```