### PR TITLE
Fix bug related to WinUsb_GetOverlappedResult() (#16)

### DIFF
--- a/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
+++ b/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
@@ -187,17 +187,17 @@ namespace LibUsbDotNet.WinUsb.Internal
                                            out int LengthTransferred) { return WinUsb_GetDescriptor(InterfaceHandle, DescriptorType, Index, LanguageID, Buffer, BufferLength, out LengthTransferred); }
 
         public override bool GetOverlappedResult(SafeHandle InterfaceHandle, IntPtr pOVERLAPPED, out int numberOfBytesTransferred, bool Wait) 
-		{ 
-			if (!InterfaceHandle.IsClosed) 
-			{
-				return WinUsb_GetOverlappedResult(InterfaceHandle, pOVERLAPPED, out numberOfBytesTransferred, Wait);
-			}
-			else
-			{
-				numberOfBytesTransferred = 0;
-				return true;
-			}			
-		}
+        {
+            if (!InterfaceHandle.IsClosed) 
+            {
+                return WinUsb_GetOverlappedResult(InterfaceHandle, pOVERLAPPED, out numberOfBytesTransferred, Wait);
+            }
+            else
+            {
+                numberOfBytesTransferred = 0;
+                return true;
+            }
+        }
         //public override bool ReadPipe(UsbEndpointBase endPointBase,
         //                              byte[] Buffer,
         //                              int BufferLength,

--- a/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
+++ b/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
@@ -186,8 +186,18 @@ namespace LibUsbDotNet.WinUsb.Internal
                                            int BufferLength,
                                            out int LengthTransferred) { return WinUsb_GetDescriptor(InterfaceHandle, DescriptorType, Index, LanguageID, Buffer, BufferLength, out LengthTransferred); }
 
-        public override bool GetOverlappedResult(SafeHandle InterfaceHandle, IntPtr pOVERLAPPED, out int numberOfBytesTransferred, bool Wait) { return WinUsb_GetOverlappedResult(InterfaceHandle, pOVERLAPPED, out numberOfBytesTransferred, Wait); }
-
+        public override bool GetOverlappedResult(SafeHandle InterfaceHandle, IntPtr pOVERLAPPED, out int numberOfBytesTransferred, bool Wait) 
+		{ 
+			if (!InterfaceHandle.IsClosed) 
+			{
+				return WinUsb_GetOverlappedResult(InterfaceHandle, pOVERLAPPED, out numberOfBytesTransferred, Wait);
+			}
+			else
+			{
+				numberOfBytesTransferred = 0;
+				return true;
+			}			
+		}
         //public override bool ReadPipe(UsbEndpointBase endPointBase,
         //                              byte[] Buffer,
         //                              int BufferLength,


### PR DESCRIPTION
Added a check when getting overlapped results to see if the interface was closed before returning the overlapped results. This fixes issue that manifests itself in a System.ObjectDisposedException being thrown upon program completion.