### PR TITLE
Add support for .NetStandard 2

### DIFF
--- a/stage/Benchmark/Benchmark.csproj
+++ b/stage/Benchmark/Benchmark.csproj
@@ -111,6 +111,10 @@
     <Content Include="UsbIco.ico" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\LibUsb.Common\LibUsb.Common.csproj">
+      <Project>{a8548f83-62b7-43d2-ab56-254a1424762a}</Project>
+      <Name>LibUsb.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\LibUsbDotNet\LibUsbDotNet.csproj">
       <Project>{0a78f6ff-5586-4052-8104-e23ff83a7ce1}</Project>
       <Name>LibUsbDotNet</Name>

--- a/stage/BenchmarkCon/BenchmarkCon.csproj
+++ b/stage/BenchmarkCon/BenchmarkCon.csproj
@@ -81,6 +81,10 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\LibUsb.Common\LibUsb.Common.csproj">
+      <Project>{a8548f83-62b7-43d2-ab56-254a1424762a}</Project>
+      <Name>LibUsb.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\LibUsbDotNet\LibUsbDotNet.csproj">
       <Project>{0a78f6ff-5586-4052-8104-e23ff83a7ce1}</Project>
       <Name>LibUsbDotNet</Name>

--- a/stage/Examples/Read.Isochronous/Read.Isochronous.csproj
+++ b/stage/Examples/Read.Isochronous/Read.Isochronous.csproj
@@ -66,6 +66,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\LibUsb.Common\LibUsb.Common.csproj">
+      <Project>{a8548f83-62b7-43d2-ab56-254a1424762a}</Project>
+      <Name>LibUsb.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\LibUsbDotNet\LibUsbDotNet.csproj">
       <Project>{0a78f6ff-5586-4052-8104-e23ff83a7ce1}</Project>
       <Name>LibUsbDotNet</Name>

--- a/stage/LibUsbDotNet/DeviceNotify/DeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/DeviceNotifier.cs
@@ -19,7 +19,7 @@
 // visit www.gnu.org.
 // 
 // 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using LibUsbDotNet.DeviceNotify.Linux;
 
 namespace LibUsbDotNet.DeviceNotify

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevNotifyNativeWindow.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevNotifyNativeWindow.cs
@@ -19,7 +19,7 @@
 // visit www.gnu.org.
 // 
 // 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System;
 using System.Windows.Forms;
 

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD1_5 || NETSTANDARD1_6
+﻿#if NETSTANDARD
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/SafeNotifyHandle.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/SafeNotifyHandle.cs
@@ -19,7 +19,7 @@
 // visit www.gnu.org.
 // 
 // 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System;
 using Microsoft.Win32.SafeHandles;
 

--- a/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifier.cs
@@ -19,7 +19,7 @@
 // visit www.gnu.org.
 // 
 // 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/stage/LibUsbDotNet/Info/UsbDeviceInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbDeviceInfo.cs
@@ -77,7 +77,7 @@ namespace LibUsbDotNet.Info
                     short[] deviceLangIDs;
                     if (mUsbDevice.GetLangIDs(out deviceLangIDs))
                     {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                         short currentCultureLangID = (short) CultureInfo.CurrentCulture.LCID;
                         foreach (short deviceLangID in deviceLangIDs)
                         {

--- a/stage/LibUsbDotNet/Internal/Kernel32.cs
+++ b/stage/LibUsbDotNet/Internal/Kernel32.cs
@@ -30,7 +30,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace LibUsbDotNet.Internal
 {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
     [SuppressUnmanagedCodeSecurity]
 #endif
     internal static class Kernel32
@@ -67,7 +67,7 @@ namespace LibUsbDotNet.Internal
                 int ret = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
                                         IntPtr.Zero,
                                         dwMessageId,
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                                         CultureInfo.CurrentCulture.LCID,
 #else
                                         0,

--- a/stage/LibUsbDotNet/Internal/RegistryKeyPermissionCheck.cs
+++ b/stage/LibUsbDotNet/Internal/RegistryKeyPermissionCheck.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD1_5 || NETSTANDARD1_6
+﻿#if NETSTANDARD
 namespace LibUsbDotNet.Internal
 {
     internal enum RegistryKeyPermissionCheck

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO.cs
@@ -82,7 +82,7 @@ namespace LibUsbDotNet.Internal.LibUsb
                         if (code == LibUsbIoCtl.GET_CUSTOM_REG_PROPERTY) break;
                         UsbError.Error(ErrorCode.Win32Error, iError, String.Format("DeviceIoControl code {0:X8} failed:{1}", code, Kernel32.FormatSystemMessage(iError)), typeof(LibUsbDriverIO));
                     } while (false);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                     hEvent.Close();
 #else
                     hEvent.Dispose();
@@ -92,7 +92,7 @@ namespace LibUsbDotNet.Internal.LibUsb
             }
             if (Kernel32.GetOverlappedResult(dev, deviceIoOverlapped.GlobalOverlapped, out ret, true))
             {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                 hEvent.Close();
 #else
                 hEvent.Dispose();
@@ -100,7 +100,7 @@ namespace LibUsbDotNet.Internal.LibUsb
                 return true;
             }
             UsbError.Error(ErrorCode.Win32Error, Marshal.GetLastWin32Error(), "GetOverlappedResult failed.\nIoCtlCode:" + code, typeof(LibUsbDriverIO));
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             hEvent.Close();
 #else
             hEvent.Dispose();

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -5,8 +5,7 @@
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
     <VersionPrefix>2.2.10</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
-    <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LibUsbDotNet.LibUsbDotNet</AssemblyName>
     <PackageId>LibUsbDotNet</PackageId>
@@ -26,8 +25,17 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
   </PropertyGroup>
+  
+  <!-- Conditionally defining constants based on target framework lets us avoid altering every precompile directive 
+    when we add support for another framework that requires no code changes.  Unfortunately we can't just append to constants... -->
+  <PropertyGroup Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netstandard\d'))">
+    <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netstandard\d'))">
+    <DefineConstants>$(DefineConstants);LIBUSBDOTNET;NETSTANDARD</DefineConstants>
+  </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netstandard\d'))">
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />

--- a/stage/LibUsbDotNet/Main/Helper.cs
+++ b/stage/LibUsbDotNet/Main/Helper.cs
@@ -34,7 +34,7 @@ namespace LibUsbDotNet.Main
     {
         private static object mIsLinux;
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         private static OperatingSystem mOs;
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace LibUsbDotNet.Main
         {
             get
             {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                 if (ReferenceEquals(mIsLinux, null))
                 {
                     switch (OSVersion.Platform.ToString())
@@ -112,7 +112,7 @@ namespace LibUsbDotNet.Main
         public static Dictionary<string, int> GetEnumData(Type type)
         {
             Dictionary<string, int> dictEnum = new Dictionary<string, int>();
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             FieldInfo[] enumFields = type.GetFields();
 #else
             FieldInfo[] enumFields = type.GetTypeInfo().GetFields();

--- a/stage/LibUsbDotNet/Main/ManualResetEventExtensions.cs
+++ b/stage/LibUsbDotNet/Main/ManualResetEventExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+﻿#if !NETSTANDARD
 using Microsoft.Win32.SafeHandles;
 using System.Threading;
 

--- a/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
+++ b/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
@@ -22,7 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -55,7 +55,7 @@ namespace LibUsbDotNet.Main
     /// <code source="..\Examples\Show.Info\ShowInfo.cs" lang="cs"/>
     /// </example>
     public class UsbDeviceFinder
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         : ISerializable
 #endif
     {
@@ -144,7 +144,7 @@ namespace LibUsbDotNet.Main
         public UsbDeviceFinder(Guid deviceInterfaceGuid)
             : this(int.MaxValue, int.MaxValue, int.MaxValue, null, deviceInterfaceGuid) { }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         /// <summary>
         /// Use a serialization stream to fill the <see cref="UsbDeviceFinder"/> class. 
         /// </summary>
@@ -225,7 +225,7 @@ namespace LibUsbDotNet.Main
             set { mVid = value; }
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 #region ISerializable Members
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace LibUsbDotNet.Main
 #endregion
 #endif
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         /// <summary>
         /// Load usb device finder properties from a binary stream.
         /// </summary>

--- a/stage/LibUsbDotNet/Main/UsbStream.cs
+++ b/stage/LibUsbDotNet/Main/UsbStream.cs
@@ -19,7 +19,7 @@
 // visit www.gnu.org.
 // 
 // 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEventHandler.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEventHandler.cs
@@ -38,7 +38,7 @@ namespace MonoLibUsb
         private static bool mRunning;
         private static MonoUsbSessionHandle mSessionHandle;
         internal static Thread mUsbEventThread;
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         private static ThreadPriority mPriority = ThreadPriority.Normal;
 #endif
 
@@ -63,7 +63,7 @@ namespace MonoLibUsb
             get { return mIsStoppedEvent.WaitOne(0); }
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         /// <summary>
         /// Thread proirity to use for the handle events thread.
         /// </summary>
@@ -152,7 +152,7 @@ namespace MonoLibUsb
             {
                 mRunning = true;
                 mUsbEventThread = new Thread(HandleEventFn);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                 mUsbEventThread.Priority = mPriority;
 #endif
                 mUsbEventThread.Start(mSessionHandle);
@@ -184,7 +184,7 @@ namespace MonoLibUsb
                     //bool bSuccess = mIsStoppedEvent.WaitOne((int)((mWaitUnixNativeTimeval.tv_sec * 1000 + mWaitUnixNativeTimeval.tv_usec) * 1.2), false);
                     if (!bSuccess)
                     {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                         mUsbEventThread.Abort();
 #endif
                         throw new UsbException(typeof(MonoUsbEventHandler), "Critical timeout failure! MonoUsbApi.HandleEventsTimeout did not return within the allotted time.");

--- a/stage/LibUsbDotNet/UsbDevice.OS.Specific.cs
+++ b/stage/LibUsbDotNet/UsbDevice.OS.Specific.cs
@@ -276,7 +276,7 @@ namespace LibUsbDotNet
             }
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         ///<summary>
         /// Gets a <see cref="System.OperatingSystem"/> object that contains the current platform identifier and version number.
         ///</summary>

--- a/stage/LibUsbDotNet/UsbEndpointReader.cs
+++ b/stage/LibUsbDotNet/UsbEndpointReader.cs
@@ -22,7 +22,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
 using System.Windows.Forms;
 #endif
 using LibUsbDotNet.Internal;
@@ -46,7 +46,7 @@ namespace LibUsbDotNet
         private bool mDataReceivedEnabled;
         private int mReadBufferSize;
         private Thread mReadThread;
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         private ThreadPriority mReadThreadPriority = ThreadPriority.Normal;
 #endif
 
@@ -97,7 +97,7 @@ namespace LibUsbDotNet
             set { mReadBufferSize = value; }
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
         /// <summary>
         /// Gets/Sets the Priority level for the read thread when <see cref="DataReceivedEnabled"/> is true.
         /// </summary>
@@ -219,7 +219,7 @@ namespace LibUsbDotNet
                     if (eReturn != ErrorCode.IoTimedOut) break;
                 }
             }
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             catch (ThreadAbortException)
             {
                 UsbError.Error(ErrorCode.ReceiveThreadTerminated,0, "ReadData:Read thread aborted.", reader);
@@ -240,12 +240,12 @@ namespace LibUsbDotNet
         private void StartReadThread()
         {
             mReadThread = new Thread(ReadData);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             mReadThread.Priority = ReadThreadPriority;
 #endif
             mReadThread.Start(TransferContext);
             Thread.Sleep(1);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             Application.DoEvents();
 #endif
         }
@@ -254,21 +254,21 @@ namespace LibUsbDotNet
         {
             Abort();
             Thread.Sleep(1);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
             Application.DoEvents();
 #endif
             DateTime dtStart = DateTime.Now;
             while (mReadThread.IsAlive && ((DateTime.Now - dtStart).TotalSeconds < 5)) // 5 sec fail-safe
             {
                 Thread.Sleep(100);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                 Application.DoEvents();
 #endif
             }
             if (mReadThread.IsAlive)
             {
                 UsbError.Error(ErrorCode.ReceiveThreadTerminated,0, "Failed stopping read thread.", this);
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
                 mReadThread.Abort();
 #endif
                 return false;

--- a/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
+++ b/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
@@ -32,7 +32,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace LibUsbDotNet.WinUsb.Internal
 {
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD
     [SuppressUnmanagedCodeSecurity]
 #endif
     internal class WinUsbAPI : UsbApiBase


### PR DESCRIPTION
So, firstly, I got an immediate build error with latest from master that was resolved by adding a reference to `LibUsb.Common` to a couple of projects in the solution.

Then second I changed all the `#if !NETSTANDARD_16 && !NETSTANDARD_15` checks to just look for a constant that gets conditionally defined in the .csproj based on the target framework.  Also that conditional is a regex that just looks for "NETSTANDARD" so we don't have to update it every time - though if we do, then you'd still not have to touch all the files and instead just alter the conditional in the .csproj.