### PR TITLE
Dispose UsbEnpointBase.UsbTransferContext 

### DIFF
--- a/src/LibUsbDotNet/Main/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/Main/UsbEndpointBase.cs
@@ -381,6 +381,15 @@ namespace LibUsbDotNet.Main
                     if (epReader.DataReceivedEnabled) epReader.DataReceivedEnabled = false;
                 }
                 Abort();
+
+	            if (!ReferenceEquals(mTransferContext, null))
+	            {
+		            mTransferContext.Dispose();
+		            mTransferContext = null;
+	            }
+
+				mUsbDevice.ActiveEndpoints.RemoveFromList(this);
+
                 mUsbDevice.ActiveEndpoints.RemoveFromList(this);
             }
             mIsDisposed = true;


### PR DESCRIPTION
Dispose UsbTransferContext of UsbEnpointBase (UsbEnpointBase.mTransferContext) when UsbEnpointBase is disposed. 

Since mTransferContext is created by, and only owned by UsbTransferContext,  not disposing it at the proper time (i.e. when UsbTransferContext is disposed) will left some resources not disposed. 

I noticed that this could sometimes prevent main from returning correctly (either hanging, or issuing error message, or sigsegv)