### PR TITLE
Use manual marshaling in GetDeviceDescriptor() in Mono and .NET Framework

### DIFF
--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -163,7 +163,11 @@ namespace MonoLibUsb
         /// <param name="deviceDescriptor">The <see cref="MonoUsbDeviceDescriptor"/> clas that will hold the data.</param>
         /// <returns>0 on success or a <see cref="MonoUsbError"/> code on failure.</returns>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_get_device_descriptor")]
+        #if NETSTANDARD1_6
         public static extern int GetDeviceDescriptor([In] MonoUsbProfileHandle deviceProfileHandle, [Out] MonoUsbDeviceDescriptor deviceDescriptor);
+        #else
+        public static extern int GetDeviceDescriptor([In] MonoUsbProfileHandle deviceProfileHandle, IntPtr deviceDescriptor);
+        #endif
 
         /// <summary>
         /// Get the USB configuration descriptor for the currently active configuration.

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfile.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfile.cs
@@ -23,9 +23,14 @@
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
 using MonoLibUsb.Descriptors;
+#if !NETSTANDARD1_6
+using System;
+using System.Runtime.InteropServices;
+#endif
 
 namespace MonoLibUsb.Profile
 {
+
     /// <summary>
     /// Representing a USB device that can be opened and used by Libusb-1.0.
     /// </summary>
@@ -143,7 +148,16 @@ namespace MonoLibUsb.Profile
 
             monoUsbDeviceDescriptor = new MonoUsbDeviceDescriptor();
             //Console.WriteLine("MonoUsbProfile:GetDeviceDescriptor");
+
+            #if NETSTANDARD1_6
             ec = (MonoUsbError) MonoUsbApi.GetDeviceDescriptor(mMonoUSBProfileHandle, monoUsbDeviceDescriptor);
+            #else
+            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(monoUsbDeviceDescriptor));
+            ec = (MonoUsbError) MonoUsbApi.GetDeviceDescriptor(mMonoUSBProfileHandle, ptr);
+            Marshal.PtrToStructure(ptr, monoUsbDeviceDescriptor);
+            Marshal.FreeHGlobal(ptr);
+            #endif
+
             if (ec != MonoUsbError.Success)
             {
 #if LIBUSBDOTNET


### PR DESCRIPTION
where the automatic one, that works in .NET Core, doesn't work.