### PR TITLE
Use the Gadget drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: csharp
 mono: none
 dotnet: 2.1.400
+sudo: required 
 
 git:
   depth: false
+
+install:
+  - ./ci/linux.sh
+ 
+before_script:
+  - lsusb
 
 script:
   - cd src/

--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,8 @@
+*.symvers
+*.order
+*.c
+.tmp_versions
+*.ko
+*.o
+*.ko.cmd
+*.o.cmd

--- a/ci/dummy_hcd-0.1/Makefile
+++ b/ci/dummy_hcd-0.1/Makefile
@@ -1,0 +1,9 @@
+obj-m := dummy_hcd.o
+KVERSION := $(shell uname -r)
+SVERSION := $(shell uname -r | grep -o "^[^-]*")
+
+all: dummy_hcd.c
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
+
+clean:
+	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) clean

--- a/ci/dummy_hcd-0.1/dkms.conf
+++ b/ci/dummy_hcd-0.1/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="dummy_hcd"
+PACKAGE_VERSION="0.1"
+CLEAN="make clean"
+MAKE[0]="make all KVERSION=$kernelver"
+BUILT_MODULE_NAME[0]="dummy_hcd"
+DEST_MODULE_LOCATION[0]="/extra"
+AUTOINSTALL="yes"

--- a/ci/linux.sh
+++ b/ci/linux.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# This script will install a dummy USB device, which we can use in our tests.
+# Ubunto doesn't ship with the dummy_hcd kernel module, so we need to build it
+# from soruce.
+
+# First, get some dependencies
+sudo apt-get install -y libusb-1.0-0-dev usbutils linux-headers-$(uname -r) dkms dpkg-dev
+
+# Get the source for the Linux kernel
+echo "deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted" | sudo tee --append /etc/apt/sources.list > /dev/null
+sudo apt-get update
+apt-get source linux-image-$(uname -r)
+
+# Prepare the driver source folder
+cp linux-*/drivers/usb/gadget/udc/dummy_hcd.c ci/dummy_hcd-0.1/
+sudo cp -r ci/dummy_hcd-0.1 /usr/src/
+
+# Build the kernel module
+sudo dkms add -m dummy_hcd -v 0.1
+sudo dkms build -m dummy_hcd -v 0.1
+sudo dkms install -m dummy_hcd -v 0.1
+
+# Install the root controller
+sudo modprobe dummy_hcd
+
+# Create a fake USB mass storage device
+dd bs=1M count=64 if=/dev/zero of=$TRAVIS_BUILD_DIR/ci/disk.img
+sudo modprobe g_mass_storage file=$TRAVIS_BUILD_DIR/ci/disk.img stall=0
+
+# Wait for the device to come online
+echo "Waiting for the mass storage device to come online"
+until [ $(lsusb | wc -l) -eq "2" ]; do
+  echo '.'
+  sleep 1s
+done
+


### PR DESCRIPTION
By default, there's no USB infrastructure enabled on Travis build machines.
One of the side effects is that libusb refuses to initialize, and we can't run any unit tests.

This PR installs the Gadget drivers and mounts a fake USB mass storage device. This should help us run some tests on Travis.