### PR TITLE
Use generated structs

### DIFF
--- a/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
+++ b/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
@@ -104,7 +104,7 @@ namespace LibUsbDotNet.Generator
                             }
                             else if(functionKind == FunctionKind.Default)
                             {
-                                return $"Native{NameConversions.ToClrName(pointee.GetTypedefName(), NameConversion.Type)}";
+                                return NameConversions.ToClrName(pointee.GetTypedefName(), NameConversion.Type);
                             }
                             else
                             {
@@ -123,7 +123,7 @@ namespace LibUsbDotNet.Generator
                             }
                             else
                             {
-                                return "IntPtr";
+                                return $"ref {NameConversions.ToClrName(spelling, NameConversion.Type)}";
                             }
 
                         default:

--- a/src/LibUsbDotNet.Generator/Struct.cs.template
+++ b/src/LibUsbDotNet.Generator/Struct.cs.template
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct {{Name}}
+    public struct {{Name}}
     {
         {{#Fields}}
         public {{Type}} {{Name}};

--- a/src/LibUsbDotNet.Generator/TypeDefVisitor.cs
+++ b/src/LibUsbDotNet.Generator/TypeDefVisitor.cs
@@ -45,7 +45,7 @@ namespace LibUsbDotNet.Generator
                             new Primitives.SafeHandle()
                             {
                                 NativeName = nativeName,
-                                Name = $"Native{NameConversions.ToClrName(nativeName, NameConversion.Type)}"
+                                Name = NameConversions.ToClrName(nativeName, NameConversion.Type)
                             });
                         return ChildVisitResult.Continue;
 

--- a/src/LibUsbDotNet.Tests/MonoLibUsbTests.cs
+++ b/src/LibUsbDotNet.Tests/MonoLibUsbTests.cs
@@ -13,7 +13,7 @@ namespace MonoLibUsb.Tests
         {
             IntPtr usbSessionPointer = IntPtr.Zero;
             var lastReturnCode = (Error)NativeMethods.Init(ref usbSessionPointer);
-            using (var usbSession = NativeContext.DangerousCreate(usbSessionPointer))
+            using (var usbSession = Context.DangerousCreate(usbSessionPointer))
             {
                 Assert.Equal(Error.Success, lastReturnCode);
             }
@@ -24,7 +24,7 @@ namespace MonoLibUsb.Tests
         {
             IntPtr usbSessionPointer = IntPtr.Zero;
             var lastReturnCode = (Error)NativeMethods.Init(ref usbSessionPointer);
-            using (var usbSession = NativeContext.DangerousCreate(usbSessionPointer))
+            using (var usbSession = Context.DangerousCreate(usbSessionPointer))
             {
                 NativeMethods.SetDebug(usbSession, 3);
             }
@@ -33,8 +33,7 @@ namespace MonoLibUsb.Tests
         [Fact]
         public void GetVersion()
         {
-            var versionPtr = NativeMethods.GetVersion();
-            var version = Marshal.PtrToStructure<MonoUsbVersion>(versionPtr);
+            var version = NativeMethods.GetVersion();
             Assert.Equal(1, version.Major);
         }
 

--- a/src/LibUsbDotNet/Generated/BosDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct BosDescriptor
+    public struct BosDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct BosDevCapabilityDescriptor
+    public struct BosDevCapabilityDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct ConfigDescriptor
+    public struct ConfigDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct ContainerIdDescriptor
+    public struct ContainerIdDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/Context.ReleaseHandle.cs
+++ b/src/LibUsbDotNet/Generated/Context.ReleaseHandle.cs
@@ -22,12 +22,12 @@
 
 namespace LibUsbDotNet
 {
-    public partial class NativeDevice
+    public partial class Context
     {
         /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
-            NativeMethods.UnrefDevice(this.handle);
+            NativeMethods.Exit(this.handle);
             return true;
         }
     }

--- a/src/LibUsbDotNet/Generated/Context.cs
+++ b/src/LibUsbDotNet/Generated/Context.cs
@@ -40,26 +40,26 @@ namespace LibUsbDotNet
     /// </summary>
     [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
     [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
-    public partial class NativeContext : SafeHandleZeroOrMinusOneIsInvalid
+    public partial class Context : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeContext"/> class.
+        /// Initializes a new instance of the <see cref="Context"/> class.
         /// </summary>
-        protected NativeContext() :
+        protected Context() :
                 base(true)
         {
             this.creationStackTrace = Environment.StackTrace;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeContext"/> class, specifying whether the handle is to be reliably released.
+        /// Initializes a new instance of the <see cref="Context"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected NativeContext(bool ownsHandle) :
+        protected Context(bool ownsHandle) :
                 base(ownsHandle)
         {
             this.creationStackTrace = Environment.StackTrace;
@@ -68,16 +68,16 @@ namespace LibUsbDotNet
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
-        public static NativeContext Zero
+        public static Context Zero
         {
             get
             {
-                return NativeContext.DangerousCreate(IntPtr.Zero);
+                return Context.DangerousCreate(IntPtr.Zero);
             }
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeContext"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="Context"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
@@ -87,38 +87,38 @@ namespace LibUsbDotNet
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeContext DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
+        public static Context DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
         {
-            NativeContext safeHandle = new NativeContext(ownsHandle);
+            Context safeHandle = new Context(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeContext"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="Context"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeContext DangerousCreate(IntPtr unsafeHandle)
+        public static Context DangerousCreate(IntPtr unsafeHandle)
         {
-            return NativeContext.DangerousCreate(unsafeHandle, true);
+            return Context.DangerousCreate(unsafeHandle, true);
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("{0} ({1})", this.handle, "NativeContext");
+            return string.Format("{0} ({1})", this.handle, "Context");
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj != null && obj.GetType() == typeof(NativeContext))
+            if (obj != null && obj.GetType() == typeof(Context))
             {
-                return ((NativeContext)obj).handle.Equals(this.handle);
+                return ((Context)obj).handle.Equals(this.handle);
             }
             else
             {
@@ -133,7 +133,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeContext"/> are equal.
+        /// Determines whether two specified instances of <see cref="Context"/> are equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -144,7 +144,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator == (NativeContext value1, NativeContext value2) 
+        public static bool operator == (Context value1, Context value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {
@@ -160,7 +160,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeContext"/> are not equal.
+        /// Determines whether two specified instances of <see cref="Context"/> are not equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -171,7 +171,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator != (NativeContext value1, NativeContext value2) 
+        public static bool operator != (Context value1, Context value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {

--- a/src/LibUsbDotNet/Generated/ControlSetup.cs
+++ b/src/LibUsbDotNet/Generated/ControlSetup.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct ControlSetup
+    public struct ControlSetup
     {
         public byte RequestType;
         public byte Request;

--- a/src/LibUsbDotNet/Generated/Device.ReleaseHandle.cs
+++ b/src/LibUsbDotNet/Generated/Device.ReleaseHandle.cs
@@ -22,12 +22,12 @@
 
 namespace LibUsbDotNet
 {
-    public partial class NativeContext
+    public partial class Device
     {
         /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
-            NativeMethods.Exit(this.handle);
+            NativeMethods.UnrefDevice(this.handle);
             return true;
         }
     }

--- a/src/LibUsbDotNet/Generated/Device.cs
+++ b/src/LibUsbDotNet/Generated/Device.cs
@@ -36,30 +36,30 @@ using System.Security.Permissions;
 namespace LibUsbDotNet
 {
     /// <summary>
-    /// Represents a wrapper class for <c>libusb_device_handle</c> handles.
+    /// Represents a wrapper class for <c>libusb_device</c> handles.
     /// </summary>
     [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
     [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
-    public partial class NativeDeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
+    public partial class Device : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeDeviceHandle"/> class.
+        /// Initializes a new instance of the <see cref="Device"/> class.
         /// </summary>
-        protected NativeDeviceHandle() :
+        protected Device() :
                 base(true)
         {
             this.creationStackTrace = Environment.StackTrace;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeDeviceHandle"/> class, specifying whether the handle is to be reliably released.
+        /// Initializes a new instance of the <see cref="Device"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected NativeDeviceHandle(bool ownsHandle) :
+        protected Device(bool ownsHandle) :
                 base(ownsHandle)
         {
             this.creationStackTrace = Environment.StackTrace;
@@ -68,16 +68,16 @@ namespace LibUsbDotNet
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
-        public static NativeDeviceHandle Zero
+        public static Device Zero
         {
             get
             {
-                return NativeDeviceHandle.DangerousCreate(IntPtr.Zero);
+                return Device.DangerousCreate(IntPtr.Zero);
             }
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeDeviceHandle"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="Device"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
@@ -87,38 +87,38 @@ namespace LibUsbDotNet
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeDeviceHandle DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
+        public static Device DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
         {
-            NativeDeviceHandle safeHandle = new NativeDeviceHandle(ownsHandle);
+            Device safeHandle = new Device(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeDeviceHandle"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="Device"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeDeviceHandle DangerousCreate(IntPtr unsafeHandle)
+        public static Device DangerousCreate(IntPtr unsafeHandle)
         {
-            return NativeDeviceHandle.DangerousCreate(unsafeHandle, true);
+            return Device.DangerousCreate(unsafeHandle, true);
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("{0} ({1})", this.handle, "NativeDeviceHandle");
+            return string.Format("{0} ({1})", this.handle, "Device");
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj != null && obj.GetType() == typeof(NativeDeviceHandle))
+            if (obj != null && obj.GetType() == typeof(Device))
             {
-                return ((NativeDeviceHandle)obj).handle.Equals(this.handle);
+                return ((Device)obj).handle.Equals(this.handle);
             }
             else
             {
@@ -133,7 +133,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeDeviceHandle"/> are equal.
+        /// Determines whether two specified instances of <see cref="Device"/> are equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -144,7 +144,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator == (NativeDeviceHandle value1, NativeDeviceHandle value2) 
+        public static bool operator == (Device value1, Device value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {
@@ -160,7 +160,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeDeviceHandle"/> are not equal.
+        /// Determines whether two specified instances of <see cref="Device"/> are not equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -171,7 +171,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator != (NativeDeviceHandle value1, NativeDeviceHandle value2) 
+        public static bool operator != (Device value1, Device value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {

--- a/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct DeviceDescriptor
+    public struct DeviceDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/DeviceHandle.ReleaseHandle.cs
+++ b/src/LibUsbDotNet/Generated/DeviceHandle.ReleaseHandle.cs
@@ -22,7 +22,7 @@
 
 namespace LibUsbDotNet
 {
-    public partial class NativeDeviceHandle
+    public partial class DeviceHandle
     {
         /// <inheritdoc/>
         protected override bool ReleaseHandle()

--- a/src/LibUsbDotNet/Generated/DeviceHandle.cs
+++ b/src/LibUsbDotNet/Generated/DeviceHandle.cs
@@ -36,30 +36,30 @@ using System.Security.Permissions;
 namespace LibUsbDotNet
 {
     /// <summary>
-    /// Represents a wrapper class for <c>libusb_device</c> handles.
+    /// Represents a wrapper class for <c>libusb_device_handle</c> handles.
     /// </summary>
     [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
     [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
-    public partial class NativeDevice : SafeHandleZeroOrMinusOneIsInvalid
+    public partial class DeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeDevice"/> class.
+        /// Initializes a new instance of the <see cref="DeviceHandle"/> class.
         /// </summary>
-        protected NativeDevice() :
+        protected DeviceHandle() :
                 base(true)
         {
             this.creationStackTrace = Environment.StackTrace;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeDevice"/> class, specifying whether the handle is to be reliably released.
+        /// Initializes a new instance of the <see cref="DeviceHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected NativeDevice(bool ownsHandle) :
+        protected DeviceHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
             this.creationStackTrace = Environment.StackTrace;
@@ -68,16 +68,16 @@ namespace LibUsbDotNet
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
-        public static NativeDevice Zero
+        public static DeviceHandle Zero
         {
             get
             {
-                return NativeDevice.DangerousCreate(IntPtr.Zero);
+                return DeviceHandle.DangerousCreate(IntPtr.Zero);
             }
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeDevice"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="DeviceHandle"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
@@ -87,38 +87,38 @@ namespace LibUsbDotNet
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeDevice DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
+        public static DeviceHandle DangerousCreate(IntPtr unsafeHandle, bool ownsHandle)
         {
-            NativeDevice safeHandle = new NativeDevice(ownsHandle);
+            DeviceHandle safeHandle = new DeviceHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
 
         /// <summary>
-        /// Creates a new <see cref="NativeDevice"/> from a <see cref="IntPtr"/>.
+        /// Creates a new <see cref="DeviceHandle"/> from a <see cref="IntPtr"/>.
         /// </summary>
         /// <param name="unsafeHandle">
         /// The underlying <see cref="IntPtr"/>
         /// </param>
         /// <returns>
         /// </returns>
-        public static NativeDevice DangerousCreate(IntPtr unsafeHandle)
+        public static DeviceHandle DangerousCreate(IntPtr unsafeHandle)
         {
-            return NativeDevice.DangerousCreate(unsafeHandle, true);
+            return DeviceHandle.DangerousCreate(unsafeHandle, true);
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return string.Format("{0} ({1})", this.handle, "NativeDevice");
+            return string.Format("{0} ({1})", this.handle, "DeviceHandle");
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj != null && obj.GetType() == typeof(NativeDevice))
+            if (obj != null && obj.GetType() == typeof(DeviceHandle))
             {
-                return ((NativeDevice)obj).handle.Equals(this.handle);
+                return ((DeviceHandle)obj).handle.Equals(this.handle);
             }
             else
             {
@@ -133,7 +133,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeDevice"/> are equal.
+        /// Determines whether two specified instances of <see cref="DeviceHandle"/> are equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -144,7 +144,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator == (NativeDevice value1, NativeDevice value2) 
+        public static bool operator == (DeviceHandle value1, DeviceHandle value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {
@@ -160,7 +160,7 @@ namespace LibUsbDotNet
         }
 
         /// <summary>
-        /// Determines whether two specified instances of <see cref="NativeDevice"/> are not equal.
+        /// Determines whether two specified instances of <see cref="DeviceHandle"/> are not equal.
         /// </summary>
         /// <param name="value1">
         /// The first pointer or handle to compare.
@@ -171,7 +171,7 @@ namespace LibUsbDotNet
         /// <returns>
         /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool operator != (NativeDevice value1, NativeDevice value2) 
+        public static bool operator != (DeviceHandle value1, DeviceHandle value2) 
         {
             if (object.Equals(value1, null) && object.Equals(value2, null))
             {

--- a/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct EndpointDescriptor
+    public struct EndpointDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/HotplugCallbackFn.cs
+++ b/src/LibUsbDotNet/Generated/HotplugCallbackFn.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate int HotplugCallbackFn(NativeContext ctx, NativeDevice device, HotplugEvent @event, IntPtr userData);
+    public delegate int HotplugCallbackFn(Context ctx, Device device, HotplugEvent @event, IntPtr userData);
 }

--- a/src/LibUsbDotNet/Generated/Interface.cs
+++ b/src/LibUsbDotNet/Generated/Interface.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct Interface
+    public struct Interface
     {
         public IntPtr Altsetting;
         public int NumAltsetting;

--- a/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct InterfaceDescriptor
+    public struct InterfaceDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct IsoPacketDescriptor
+    public struct IsoPacketDescriptor
     {
         public uint Length;
         public uint ActualLength;

--- a/src/LibUsbDotNet/Generated/NativeMethods.cs
+++ b/src/LibUsbDotNet/Generated/NativeMethods.cs
@@ -57,10 +57,10 @@ namespace LibUsbDotNet
         public static extern void Exit(IntPtr ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_debug")]
-        public static extern void SetDebug(NativeContext ctx, int level);
+        public static extern void SetDebug(Context ctx, int level);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_version")]
-        public static extern IntPtr GetVersion();
+        public static extern ref Version GetVersion();
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_has_capability")]
         public static extern int HasCapability(uint capability);
@@ -75,238 +75,238 @@ namespace LibUsbDotNet
         public static extern IntPtr StrError(Error errcode);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device_list")]
-        public static extern IntPtr GetDeviceList(NativeContext ctx, ref IntPtr list);
+        public static extern IntPtr GetDeviceList(Context ctx, ref IntPtr list);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_device_list")]
         public static extern void FreeDeviceList(ref IntPtr list, int unrefDevices);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_ref_device")]
-        public static extern NativeDevice RefDevice(NativeDevice dev);
+        public static extern Device RefDevice(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_unref_device")]
         public static extern void UnrefDevice(IntPtr dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_configuration")]
-        public static extern Error GetConfiguration(NativeDeviceHandle dev, ref int config);
+        public static extern Error GetConfiguration(DeviceHandle dev, ref int config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device_descriptor")]
-        public static extern Error GetDeviceDescriptor(NativeDevice dev, IntPtr desc);
+        public static extern Error GetDeviceDescriptor(Device dev, ref DeviceDescriptor desc);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_active_config_descriptor")]
-        public static extern Error GetActiveConfigDescriptor(NativeDevice dev, ref IntPtr config);
+        public static extern Error GetActiveConfigDescriptor(Device dev, ref IntPtr config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_config_descriptor")]
-        public static extern Error GetConfigDescriptor(NativeDevice dev, byte configIndex, ref IntPtr config);
+        public static extern Error GetConfigDescriptor(Device dev, byte configIndex, ref IntPtr config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_config_descriptor_by_value")]
-        public static extern Error GetConfigDescriptorByValue(NativeDevice dev, byte bconfigurationvalue, ref IntPtr config);
+        public static extern Error GetConfigDescriptorByValue(Device dev, byte bconfigurationvalue, ref IntPtr config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_config_descriptor")]
-        public static extern void FreeConfigDescriptor(IntPtr config);
+        public static extern void FreeConfigDescriptor(ref ConfigDescriptor config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_endpoint_companion_descriptor")]
-        public static extern Error GetSsEndpointCompanionDescriptor(IntPtr ctx, IntPtr endpoint, ref IntPtr epComp);
+        public static extern Error GetSsEndpointCompanionDescriptor(ref Context ctx, ref EndpointDescriptor endpoint, ref IntPtr epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_endpoint_companion_descriptor")]
-        public static extern void FreeSsEndpointCompanionDescriptor(IntPtr epComp);
+        public static extern void FreeSsEndpointCompanionDescriptor(ref SsEndpointCompanionDescriptor epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_bos_descriptor")]
-        public static extern Error GetBosDescriptor(NativeDeviceHandle devHandle, ref IntPtr bos);
+        public static extern Error GetBosDescriptor(DeviceHandle devHandle, ref IntPtr bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_bos_descriptor")]
-        public static extern void FreeBosDescriptor(IntPtr bos);
+        public static extern void FreeBosDescriptor(ref BosDescriptor bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_usb_2_0_extension_descriptor")]
-        public static extern Error GetUsb20ExtensionDescriptor(IntPtr ctx, IntPtr devCap, ref IntPtr usb20Extension);
+        public static extern Error GetUsb20ExtensionDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_usb_2_0_extension_descriptor")]
-        public static extern void FreeUsb20ExtensionDescriptor(IntPtr usb20Extension);
+        public static extern void FreeUsb20ExtensionDescriptor(ref Usb20ExtensionDescriptor usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_usb_device_capability_descriptor")]
-        public static extern Error GetSsUsbDeviceCapabilityDescriptor(IntPtr ctx, IntPtr devCap, ref IntPtr ssUsbDeviceCap);
+        public static extern Error GetSsUsbDeviceCapabilityDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_usb_device_capability_descriptor")]
-        public static extern void FreeSsUsbDeviceCapabilityDescriptor(IntPtr ssUsbDeviceCap);
+        public static extern void FreeSsUsbDeviceCapabilityDescriptor(ref SsUsbDeviceCapabilityDescriptor ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_container_id_descriptor")]
-        public static extern Error GetContainerIdDescriptor(IntPtr ctx, IntPtr devCap, ref IntPtr containerId);
+        public static extern Error GetContainerIdDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr containerId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_container_id_descriptor")]
-        public static extern void FreeContainerIdDescriptor(IntPtr containerId);
+        public static extern void FreeContainerIdDescriptor(ref ContainerIdDescriptor containerId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_bus_number")]
-        public static extern byte GetBusNumber(NativeDevice dev);
+        public static extern byte GetBusNumber(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_port_number")]
-        public static extern byte GetPortNumber(NativeDevice dev);
+        public static extern byte GetPortNumber(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_port_numbers")]
-        public static extern Error GetPortNumbers(NativeDevice dev, ref byte portNumbers, int portNumbersLen);
+        public static extern Error GetPortNumbers(Device dev, ref byte portNumbers, int portNumbersLen);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_port_path")]
-        public static extern Error GetPortPath(NativeContext ctx, NativeDevice dev, ref byte path, byte pathLength);
+        public static extern Error GetPortPath(Context ctx, Device dev, ref byte path, byte pathLength);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_parent")]
-        public static extern NativeDevice GetParent(NativeDevice dev);
+        public static extern Device GetParent(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device_address")]
-        public static extern byte GetDeviceAddress(NativeDevice dev);
+        public static extern byte GetDeviceAddress(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device_speed")]
-        public static extern int GetDeviceSpeed(NativeDevice dev);
+        public static extern int GetDeviceSpeed(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_max_packet_size")]
-        public static extern int GetMaxPacketSize(NativeDevice dev, byte endpoint);
+        public static extern int GetMaxPacketSize(Device dev, byte endpoint);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_max_iso_packet_size")]
-        public static extern int GetMaxIsoPacketSize(NativeDevice dev, byte endpoint);
+        public static extern int GetMaxIsoPacketSize(Device dev, byte endpoint);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_open")]
-        public static extern Error Open(NativeDevice dev, ref IntPtr devHandle);
+        public static extern Error Open(Device dev, ref IntPtr devHandle);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_close")]
         public static extern void Close(IntPtr devHandle);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device")]
-        public static extern NativeDevice GetDevice(NativeDeviceHandle devHandle);
+        public static extern Device GetDevice(DeviceHandle devHandle);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_configuration")]
-        public static extern Error SetConfiguration(NativeDeviceHandle devHandle, int configuration);
+        public static extern Error SetConfiguration(DeviceHandle devHandle, int configuration);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_claim_interface")]
-        public static extern Error ClaimInterface(NativeDeviceHandle devHandle, int interfaceNumber);
+        public static extern Error ClaimInterface(DeviceHandle devHandle, int interfaceNumber);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_release_interface")]
-        public static extern Error ReleaseInterface(NativeDeviceHandle devHandle, int interfaceNumber);
+        public static extern Error ReleaseInterface(DeviceHandle devHandle, int interfaceNumber);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_open_device_with_vid_pid")]
-        public static extern NativeDeviceHandle OpenDeviceWithVidPid(NativeContext ctx, ushort vendorId, ushort productId);
+        public static extern DeviceHandle OpenDeviceWithVidPid(Context ctx, ushort vendorId, ushort productId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_interface_alt_setting")]
-        public static extern Error SetInterfaceAltSetting(NativeDeviceHandle devHandle, int interfaceNumber, int alternateSetting);
+        public static extern Error SetInterfaceAltSetting(DeviceHandle devHandle, int interfaceNumber, int alternateSetting);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_clear_halt")]
-        public static extern Error ClearHalt(NativeDeviceHandle devHandle, byte endpoint);
+        public static extern Error ClearHalt(DeviceHandle devHandle, byte endpoint);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_reset_device")]
-        public static extern Error ResetDevice(NativeDeviceHandle devHandle);
+        public static extern Error ResetDevice(DeviceHandle devHandle);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_alloc_streams")]
-        public static extern Error AllocStreams(NativeDeviceHandle devHandle, uint numStreams, IntPtr endpoints, int numEndpoints);
+        public static extern Error AllocStreams(DeviceHandle devHandle, uint numStreams, IntPtr endpoints, int numEndpoints);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_streams")]
-        public static extern Error FreeStreams(NativeDeviceHandle devHandle, IntPtr endpoints, int numEndpoints);
+        public static extern Error FreeStreams(DeviceHandle devHandle, IntPtr endpoints, int numEndpoints);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_dev_mem_alloc")]
-        public static extern IntPtr DevMemAlloc(NativeDeviceHandle devHandle, UIntPtr length);
+        public static extern IntPtr DevMemAlloc(DeviceHandle devHandle, UIntPtr length);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_dev_mem_free")]
-        public static extern Error DevMemFree(NativeDeviceHandle devHandle, IntPtr buffer, UIntPtr length);
+        public static extern Error DevMemFree(DeviceHandle devHandle, IntPtr buffer, UIntPtr length);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_kernel_driver_active")]
-        public static extern int KernelDriverActive(NativeDeviceHandle devHandle, int interfaceNumber);
+        public static extern int KernelDriverActive(DeviceHandle devHandle, int interfaceNumber);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_detach_kernel_driver")]
-        public static extern Error DetachKernelDriver(NativeDeviceHandle devHandle, int interfaceNumber);
+        public static extern Error DetachKernelDriver(DeviceHandle devHandle, int interfaceNumber);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_attach_kernel_driver")]
-        public static extern Error AttachKernelDriver(NativeDeviceHandle devHandle, int interfaceNumber);
+        public static extern Error AttachKernelDriver(DeviceHandle devHandle, int interfaceNumber);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_auto_detach_kernel_driver")]
-        public static extern Error SetAutoDetachKernelDriver(NativeDeviceHandle devHandle, int enable);
+        public static extern Error SetAutoDetachKernelDriver(DeviceHandle devHandle, int enable);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_alloc_transfer")]
-        public static extern IntPtr AllocTransfer(int isoPackets);
+        public static extern ref Transfer AllocTransfer(int isoPackets);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_submit_transfer")]
-        public static extern Error SubmitTransfer(IntPtr transfer);
+        public static extern Error SubmitTransfer(ref Transfer transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_cancel_transfer")]
-        public static extern Error CancelTransfer(IntPtr transfer);
+        public static extern Error CancelTransfer(ref Transfer transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_transfer")]
-        public static extern void FreeTransfer(IntPtr transfer);
+        public static extern void FreeTransfer(ref Transfer transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_transfer_set_stream_id")]
-        public static extern void TransferSetStreamId(IntPtr transfer, uint streamId);
+        public static extern void TransferSetStreamId(ref Transfer transfer, uint streamId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_transfer_get_stream_id")]
-        public static extern uint TransferGetStreamId(IntPtr transfer);
+        public static extern uint TransferGetStreamId(ref Transfer transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_control_transfer")]
-        public static extern int ControlTransfer(NativeDeviceHandle devHandle, byte requestType, byte brequest, ushort wvalue, ushort windex, IntPtr data, ushort wlength, uint timeout);
+        public static extern int ControlTransfer(DeviceHandle devHandle, byte requestType, byte brequest, ushort wvalue, ushort windex, IntPtr data, ushort wlength, uint timeout);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_bulk_transfer")]
-        public static extern Error BulkTransfer(NativeDeviceHandle devHandle, byte endpoint, IntPtr data, int length, ref int actualLength, uint timeout);
+        public static extern Error BulkTransfer(DeviceHandle devHandle, byte endpoint, IntPtr data, int length, ref int actualLength, uint timeout);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_interrupt_transfer")]
-        public static extern Error InterruptTransfer(NativeDeviceHandle devHandle, byte endpoint, IntPtr data, int length, ref int actualLength, uint timeout);
+        public static extern Error InterruptTransfer(DeviceHandle devHandle, byte endpoint, IntPtr data, int length, ref int actualLength, uint timeout);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_string_descriptor_ascii")]
-        public static extern Error GetStringDescriptorAscii(NativeDeviceHandle devHandle, byte descIndex, IntPtr data, int length);
+        public static extern Error GetStringDescriptorAscii(DeviceHandle devHandle, byte descIndex, IntPtr data, int length);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_try_lock_events")]
-        public static extern int TryLockEvents(NativeContext ctx);
+        public static extern int TryLockEvents(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_lock_events")]
-        public static extern void LockEvents(NativeContext ctx);
+        public static extern void LockEvents(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_unlock_events")]
-        public static extern void UnlockEvents(NativeContext ctx);
+        public static extern void UnlockEvents(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_event_handling_ok")]
-        public static extern int EventHandlingOk(NativeContext ctx);
+        public static extern int EventHandlingOk(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_event_handler_active")]
-        public static extern int EventHandlerActive(NativeContext ctx);
+        public static extern int EventHandlerActive(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_interrupt_event_handler")]
-        public static extern void InterruptEventHandler(NativeContext ctx);
+        public static extern void InterruptEventHandler(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_lock_event_waiters")]
-        public static extern void LockEventWaiters(NativeContext ctx);
+        public static extern void LockEventWaiters(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_unlock_event_waiters")]
-        public static extern void UnlockEventWaiters(NativeContext ctx);
+        public static extern void UnlockEventWaiters(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_wait_for_event")]
-        public static extern int WaitForEvent(NativeContext ctx, ref UnixNativeTimeval tv);
+        public static extern int WaitForEvent(Context ctx, ref UnixNativeTimeval tv);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_handle_events_timeout")]
-        public static extern Error HandleEventsTimeout(NativeContext ctx, ref UnixNativeTimeval tv);
+        public static extern Error HandleEventsTimeout(Context ctx, ref UnixNativeTimeval tv);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_handle_events_timeout_completed")]
-        public static extern Error HandleEventsTimeoutCompleted(NativeContext ctx, ref UnixNativeTimeval tv, ref int completed);
+        public static extern Error HandleEventsTimeoutCompleted(Context ctx, ref UnixNativeTimeval tv, ref int completed);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_handle_events")]
-        public static extern Error HandleEvents(NativeContext ctx);
+        public static extern Error HandleEvents(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_handle_events_completed")]
-        public static extern Error HandleEventsCompleted(NativeContext ctx, ref int completed);
+        public static extern Error HandleEventsCompleted(Context ctx, ref int completed);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_handle_events_locked")]
-        public static extern Error HandleEventsLocked(NativeContext ctx, ref UnixNativeTimeval tv);
+        public static extern Error HandleEventsLocked(Context ctx, ref UnixNativeTimeval tv);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_pollfds_handle_timeouts")]
-        public static extern Error PollfdsHandleTimeouts(NativeContext ctx);
+        public static extern Error PollfdsHandleTimeouts(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_next_timeout")]
-        public static extern Error GetNextTimeout(NativeContext ctx, ref UnixNativeTimeval tv);
+        public static extern Error GetNextTimeout(Context ctx, ref UnixNativeTimeval tv);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_pollfds")]
-        public static extern ref IntPtr GetPollfds(NativeContext ctx);
+        public static extern ref IntPtr GetPollfds(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_pollfds")]
         public static extern void FreePollfds(ref IntPtr pollfds);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_pollfd_notifiers")]
-        public static extern void SetPollfdNotifiers(NativeContext ctx, IntPtr addedDelegate, IntPtr removedDelegate, IntPtr userData);
+        public static extern void SetPollfdNotifiers(Context ctx, IntPtr addedDelegate, IntPtr removedDelegate, IntPtr userData);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_hotplug_register_callback")]
-        public static extern Error HotplugRegisterCallback(NativeContext ctx, HotplugEvent events, HotplugFlag flags, int vendorId, int productId, int devClass, IntPtr Delegate, IntPtr userData, ref int callbackHandle);
+        public static extern Error HotplugRegisterCallback(Context ctx, HotplugEvent events, HotplugFlag flags, int vendorId, int productId, int devClass, IntPtr Delegate, IntPtr userData, ref int callbackHandle);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_hotplug_deregister_callback")]
-        public static extern void HotplugDeregisterCallback(NativeContext ctx, int callbackHandle);
+        public static extern void HotplugDeregisterCallback(Context ctx, int callbackHandle);
 
     }
 }

--- a/src/LibUsbDotNet/Generated/Pollfd.cs
+++ b/src/LibUsbDotNet/Generated/Pollfd.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct Pollfd
+    public struct Pollfd
     {
         public int Fd;
         public short Events;

--- a/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct SsEndpointCompanionDescriptor
+    public struct SsEndpointCompanionDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct SsUsbDeviceCapabilityDescriptor
+    public struct SsUsbDeviceCapabilityDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/Transfer.cs
+++ b/src/LibUsbDotNet/Generated/Transfer.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct Transfer
+    public struct Transfer
     {
     }
 }

--- a/src/LibUsbDotNet/Generated/TransferDelegate.cs
+++ b/src/LibUsbDotNet/Generated/TransferDelegate.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate void TransferDelegate(IntPtr transfer);
+    public delegate void TransferDelegate(ref Transfer transfer);
 }

--- a/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct Usb20ExtensionDescriptor
+    public struct Usb20ExtensionDescriptor
     {
         public byte Length;
         public byte DescriptorType;

--- a/src/LibUsbDotNet/Generated/Version.cs
+++ b/src/LibUsbDotNet/Generated/Version.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    internal struct Version
+    public struct Version
     {
         public ushort Major;
         public ushort Minor;

--- a/src/LibUsbDotNet/LibUsb/MonoLibUsbApiHelpers.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoLibUsbApiHelpers.cs
@@ -79,7 +79,7 @@ namespace MonoLibUsb
         /// <param name="pData">Output buffer for descriptor.</param>
         /// <param name="length">Size of data buffer.</param>
         /// <returns>Number of bytes returned in data, or a <see cref="Error"/> code on failure.</returns>
-        public static int GetDescriptor(NativeDeviceHandle deviceHandle, byte descType, byte descIndex, IntPtr pData, int length)
+        public static int GetDescriptor(DeviceHandle deviceHandle, byte descType, byte descIndex, IntPtr pData, int length)
         {
             return ControlTransfer(deviceHandle,
                                            (byte)EndpointDirection.In,
@@ -104,7 +104,7 @@ namespace MonoLibUsb
         /// <param name="data">Output buffer for descriptor. This object is pinned using <see cref="PinnedHandle"/>.</param>
         /// <param name="length">Size of data buffer.</param>
         /// <returns>Number of bytes returned in data, or <see cref="Error"/> code on failure.</returns>
-        public static int GetDescriptor(NativeDeviceHandle deviceHandle, byte descType, byte descIndex, object data, int length)
+        public static int GetDescriptor(DeviceHandle deviceHandle, byte descType, byte descIndex, object data, int length)
         {
             PinnedHandle p = new PinnedHandle(data);
             return GetDescriptor(deviceHandle, descType, descIndex, p.Handle, length);
@@ -124,11 +124,11 @@ namespace MonoLibUsb
         /// <param name="vendorID">The idVendor value to search for.</param>
         /// <param name="productID">The idProduct value to search for.</param>
         /// <returns>Null if the device was not opened or not found, otherwise an opened device handle.</returns>
-        public static NativeDeviceHandle OpenDeviceWithVidPid([In]NativeContext sessionHandle, ushort vendorID, ushort productID)
+        public static DeviceHandle OpenDeviceWithVidPid([In]Context sessionHandle, ushort vendorID, ushort productID)
         {
             var pHandle = NativeMethods.OpenDeviceWithVidPid(sessionHandle, vendorID, productID);
-            if (pHandle == NativeDeviceHandle.Zero) return null;
-            return NativeDeviceHandle.DangerousCreate(pHandle.DangerousGetHandle());
+            if (pHandle == DeviceHandle.Zero) return null;
+            return DeviceHandle.DangerousCreate(pHandle.DangerousGetHandle());
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace MonoLibUsb
         /// </remarks>
         /// <param name="devicehandle">A device handle.</param>
         /// <returns>The underlying profile handle.</returns>
-        public static MonoUsbProfileHandle GetDevice(NativeDeviceHandle devicehandle)
+        public static MonoUsbProfileHandle GetDevice(DeviceHandle devicehandle)
         {
             var device = NativeMethods.GetDevice(devicehandle);
             return new MonoUsbProfileHandle(device.DangerousGetHandle());
@@ -197,7 +197,7 @@ namespace MonoLibUsb
         /// <item>another <see cref="Error"/> code on other failures</item>
         /// </list>
         /// </returns>
-        public static int BulkTransfer(NativeDeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
+        public static int BulkTransfer(DeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
         {
             PinnedHandle p = new PinnedHandle(data);
             int ret = BulkTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
@@ -249,7 +249,7 @@ namespace MonoLibUsb
         /// <item>another <see cref="Error"/> code on other failures</item>
         /// </list>
         /// </returns>
-        public static int InterruptTransfer(NativeDeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
+        public static int InterruptTransfer(DeviceHandle deviceHandle, byte endpoint, object data, int length, out int actualLength, int timeout)
         {
             PinnedHandle p = new PinnedHandle(data);
             int ret = InterruptTransfer(deviceHandle, endpoint, p.Handle, length, out actualLength, timeout);
@@ -282,7 +282,7 @@ namespace MonoLibUsb
         /// <item>another <see cref="Error"/> code on other failures</item>
         /// </list>
         /// </returns>
-        public static int ControlTransferAsync(NativeDeviceHandle deviceHandle, byte requestType, byte request, short value, short index, IntPtr pData, short dataLength, int timeout)
+        public static int ControlTransferAsync(DeviceHandle deviceHandle, byte requestType, byte request, short value, short index, IntPtr pData, short dataLength, int timeout)
         {
             MonoUsbControlSetupHandle setupHandle = new MonoUsbControlSetupHandle(requestType, request, value, index, pData, dataLength);
             MonoUsbTransfer transfer = new MonoUsbTransfer(0);
@@ -299,7 +299,7 @@ namespace MonoLibUsb
                 return r;
             }
             IntPtr pSessionHandle;
-            NativeContext sessionHandle = MonoUsbEventHandler.SessionHandle;
+            Context sessionHandle = MonoUsbEventHandler.SessionHandle;
             if (sessionHandle == null)
                 pSessionHandle = IntPtr.Zero;
             else
@@ -380,7 +380,7 @@ namespace MonoLibUsb
         /// <item>another <see cref="Error"/> code on other failures</item>
         /// </list>
         /// </returns>
-        public static int ControlTransfer(NativeDeviceHandle deviceHandle, byte requestType, byte request, short value, short index, object data, short dataLength, int timeout)
+        public static int ControlTransfer(DeviceHandle deviceHandle, byte requestType, byte request, short value, short index, object data, short dataLength, int timeout)
         {
             PinnedHandle p = new PinnedHandle(data);
             int ret = ControlTransfer(deviceHandle, requestType, request, value, index, p.Handle, dataLength, timeout);
@@ -400,7 +400,7 @@ namespace MonoLibUsb
         /// </remarks>
         /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
         /// <returns>A list of PollfdItem structures, or null on error.</returns>
-        public static List<PollfdItem> GetPollfds(NativeContext sessionHandle)
+        public static List<PollfdItem> GetPollfds(Context sessionHandle)
         {
             List<PollfdItem> rtnList = new List<PollfdItem>();
             IntPtr pList = NativeMethods.GetPollfds(sessionHandle);

--- a/src/LibUsbDotNet/LibUsb/MonoUsbDevice.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoUsbDevice.cs
@@ -137,7 +137,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             if (!IsOpen) throw new UsbException(this, "Device is not opened.");
             ActiveEndpoints.Clear();
 
-            if ((ret = NativeMethods.ResetDevice((NativeDeviceHandle) mUsbHandle)) != Error.Success)
+            if ((ret = NativeMethods.ResetDevice((DeviceHandle) mUsbHandle)) != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "ResetDevice Failed", this);
             }
@@ -188,7 +188,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override bool ControlTransfer(ref UsbSetupPacket setupPacket, IntPtr buffer, int bufferLength, out int lengthTransferred)
         {
             Debug.WriteLine(GetType().Name + ".ControlTransfer() Before", "Libusb-1.0");
-            int ret = MonoUsbApi.ControlTransferAsync((NativeDeviceHandle) mUsbHandle,
+            int ret = MonoUsbApi.ControlTransferAsync((DeviceHandle) mUsbHandle,
                                                       setupPacket.RequestType,
                                                       setupPacket.Request,
                                                       setupPacket.Value,
@@ -226,7 +226,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             if (!wasOpen) Open();
             if (!IsOpen) return false;
 
-            int ret = MonoUsbApi.GetDescriptor((NativeDeviceHandle) mUsbHandle, descriptorType, index, buffer, (ushort) bufferLength);
+            int ret = MonoUsbApi.GetDescriptor((DeviceHandle) mUsbHandle, descriptorType, index, buffer, (ushort) bufferLength);
 
             if (ret < 0)
             {
@@ -253,10 +253,10 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override bool Open()
         {
             if (IsOpen) return true;
-            var nativeDevice = NativeDevice.DangerousCreate(mMonoUSBProfile.ProfileHandle.DangerousGetHandle(), false);
+            var nativeDevice = Device.DangerousCreate(mMonoUSBProfile.ProfileHandle.DangerousGetHandle(), false);
             IntPtr ptr = IntPtr.Zero;
             var ret = NativeMethods.Open(nativeDevice, ref ptr);
-            NativeDeviceHandle handle = NativeDeviceHandle.DangerousCreate(ptr);
+            DeviceHandle handle = DeviceHandle.DangerousCreate(ptr);
             if (handle.IsInvalid)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "MonoUsbDevice.Open Failed", this);
@@ -327,7 +327,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// </remarks>
         public bool SetConfiguration(byte config)
         {
-            var ret = NativeMethods.SetConfiguration((NativeDeviceHandle) mUsbHandle, config);
+            var ret = NativeMethods.SetConfiguration((DeviceHandle) mUsbHandle, config);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "SetConfiguration Failed", this);
@@ -346,7 +346,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         {
             config = 0;
             int iconfig = 0;
-            var ret = NativeMethods.GetConfiguration((NativeDeviceHandle) mUsbHandle, ref iconfig);
+            var ret = NativeMethods.GetConfiguration((DeviceHandle) mUsbHandle, ref iconfig);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "GetConfiguration Failed", this);
@@ -414,7 +414,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         {
             if (mClaimedInterfaces.Contains(interfaceID)) return true;
 
-            var ret = NativeMethods.ClaimInterface((NativeDeviceHandle)mUsbHandle, interfaceID);
+            var ret = NativeMethods.ClaimInterface((DeviceHandle)mUsbHandle, interfaceID);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "ClaimInterface Failed", this);
@@ -448,7 +448,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// <returns>True on success.</returns>
         public bool ReleaseInterface(int interfaceID)
         {
-            var ret = NativeMethods.ReleaseInterface((NativeDeviceHandle) mUsbHandle, interfaceID);
+            var ret = NativeMethods.ReleaseInterface((DeviceHandle) mUsbHandle, interfaceID);
             if (!mClaimedInterfaces.Remove(interfaceID)) return true;
 
             if (ret != Error.Success)
@@ -466,7 +466,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// <returns>True on success.</returns>
         public bool SetAltInterface(int interfaceID, int alternateID)
         {
-            var ret = NativeMethods.SetInterfaceAltSetting((NativeDeviceHandle) mUsbHandle, interfaceID, alternateID);
+            var ret = NativeMethods.SetInterfaceAltSetting((DeviceHandle) mUsbHandle, interfaceID, alternateID);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "SetAltInterface Failed", this);

--- a/src/LibUsbDotNet/LibUsb/MonoUsbEndpointReader.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoUsbEndpointReader.cs
@@ -67,7 +67,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         {
             if (IsDisposed) throw new ObjectDisposedException(GetType().Name);
             Abort();
-            var ret = NativeMethods.ClearHalt((NativeDeviceHandle)Device.Handle, EpNum);
+            var ret = NativeMethods.ClearHalt((DeviceHandle)Device.Handle, EpNum);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "Endpoint Reset Failed", this);

--- a/src/LibUsbDotNet/LibUsb/MonoUsbEndpointWriter.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoUsbEndpointWriter.cs
@@ -62,7 +62,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         {
             if (IsDisposed) throw new ObjectDisposedException(GetType().Name);
             Abort();
-            var ret = NativeMethods.ClearHalt((NativeDeviceHandle) Device.Handle, EpNum);
+            var ret = NativeMethods.ClearHalt((DeviceHandle) Device.Handle, EpNum);
             if (ret != Error.Success)
             {
                 MonoUsbErrorMessage.Error(ErrorCode.MonoApiError, (int)ret, "Endpoint Reset Failed", this);

--- a/src/LibUsbDotNet/LibUsb/MonoUsbEventHandler.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoUsbEventHandler.cs
@@ -37,7 +37,7 @@ namespace MonoLibUsb
     {
         private static readonly ManualResetEvent mIsStoppedEvent = new ManualResetEvent(true);
         private static bool mRunning;
-        private static NativeContext mSessionHandle;
+        private static Context mSessionHandle;
         internal static Thread mUsbEventThread;
 #if !NETSTANDARD1_5 && !NETSTANDARD1_6
         private static ThreadPriority mPriority = ThreadPriority.Normal;
@@ -51,7 +51,7 @@ namespace MonoLibUsb
         /// <remarks>
         /// Used for MonoLibUsb members that require the <see cref="MonoUsbSessionHandle"/> parameter.
         /// </remarks>
-        public static NativeContext SessionHandle
+        public static Context SessionHandle
         {
             get { return mSessionHandle; }
         }
@@ -90,7 +90,7 @@ namespace MonoLibUsb
 
         private static void HandleEventFn(object oHandle)
         {
-            var sessionHandle = oHandle as NativeContext;
+            var sessionHandle = oHandle as Context;
 
             mIsStoppedEvent.Reset();
 
@@ -127,7 +127,7 @@ namespace MonoLibUsb
                 mWaitUnixNativeTimeval = unixNativeTimeval;
                 IntPtr ctx = IntPtr.Zero;
                 NativeMethods.Init(ref ctx);
-                mSessionHandle=NativeContext.DangerousCreate(ctx);
+                mSessionHandle=Context.DangerousCreate(ctx);
                 if (mSessionHandle.IsInvalid)
                 {
                     mSessionHandle = null;

--- a/src/LibUsbDotNet/LibUsb/Profile/MonoUsbProfile.cs
+++ b/src/LibUsbDotNet/LibUsb/Profile/MonoUsbProfile.cs
@@ -168,12 +168,12 @@ namespace MonoLibUsb.Profile
         /// <returns>
         /// A new <see cref="MonoUsbDeviceHandle"/> instance. Created with <see cref="MonoUsbDeviceHandle(MonoUsbProfileHandle)"/> constructor.
         /// </returns>
-        public NativeDeviceHandle OpenDeviceHandle()
+        public DeviceHandle OpenDeviceHandle()
         {
-            NativeDevice device = NativeDevice.DangerousCreate(ProfileHandle.DangerousGetHandle());
+            Device device = Device.DangerousCreate(ProfileHandle.DangerousGetHandle());
             IntPtr devHandle = IntPtr.Zero;
             NativeMethods.Open(device, ref devHandle);
-            return NativeDeviceHandle.DangerousCreate(devHandle);
+            return DeviceHandle.DangerousCreate(devHandle);
         }
 
         /// <summary>

--- a/src/LibUsbDotNet/LibUsb/Profile/MonoUsbProfileList.cs
+++ b/src/LibUsbDotNet/LibUsb/Profile/MonoUsbProfileList.cs
@@ -115,7 +115,7 @@ namespace MonoLibUsb.Profile
         /// <example>
         /// <code source="..\MonoLibUsb\MonoUsb.ShowInfo\ShowInfo.cs" lang="cs"/>
         /// </example>
-        public int Refresh(NativeContext sessionHandle)
+        public int Refresh(Context sessionHandle)
         {
             lock (LockProfileList)
             {

--- a/src/LibUsbDotNet/LibUsb/Transfer/MonoUsbTransfer.cs
+++ b/src/LibUsbDotNet/LibUsb/Transfer/MonoUsbTransfer.cs
@@ -279,7 +279,7 @@ namespace MonoLibUsb.Transfer
         /// <param name="callback">callback function to be invoked on transfer completion</param>
         /// <param name="userData">user data to pass to callback function</param>
         /// <param name="timeout">timeout for the transfer in milliseconds</param>
-        public void FillBulk(NativeDeviceHandle devHandle,
+        public void FillBulk(DeviceHandle devHandle,
                          byte endpoint,
                          IntPtr buffer,
                          int length,
@@ -318,7 +318,7 @@ namespace MonoLibUsb.Transfer
         /// <param name="callback">callback function to be invoked on transfer completion</param>
         /// <param name="userData">user data to pass to callback function</param>
         /// <param name="timeout">timeout for the transfer in milliseconds</param>
-        public void FillInterrupt(NativeDeviceHandle devHandle,
+        public void FillInterrupt(DeviceHandle devHandle,
                  byte endpoint,
                  IntPtr buffer,
                  int length,
@@ -357,7 +357,7 @@ namespace MonoLibUsb.Transfer
         /// <param name="callback">callback function to be invoked on transfer completion</param>
         /// <param name="userData">user data to pass to callback function</param>
         /// <param name="timeout">timeout for the transfer in milliseconds</param>
-        public void FillIsochronous(NativeDeviceHandle devHandle,
+        public void FillIsochronous(DeviceHandle devHandle,
                  byte endpoint,
                  IntPtr buffer,
                  int length,int numIsoPackets,
@@ -500,7 +500,7 @@ namespace MonoLibUsb.Transfer
         /// <param name="callback">callback function to be invoked on transfer completion</param>
         /// <param name="userData">user data to pass to callback function</param>
         /// <param name="timeout">timeout for the transfer in milliseconds</param>
-        public void FillControl(NativeDeviceHandle devHandle, MonoUsbControlSetupHandle controlSetupHandle, Delegate callback, IntPtr userData, int timeout) 
+        public void FillControl(DeviceHandle devHandle, MonoUsbControlSetupHandle controlSetupHandle, Delegate callback, IntPtr userData, int timeout) 
         {
             PtrDeviceHandle = devHandle.DangerousGetHandle();
             Endpoint = 0;


### PR DESCRIPTION
Where possible, have the P/Invoke declarations uses the generated `struct`s instead of `IntPtr`s. Drop the `Native` prefix for handles.