### PR TITLE
Further struct finetuning

### DIFF
--- a/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
+++ b/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
@@ -111,7 +111,7 @@ namespace LibUsbDotNet.Generator
                             }
                             else if (typeDefName == "uint8_t")
                             {
-                                return "ref byte";
+                                return "byte*";
                             }
                             else if(functionKind == FunctionKind.Default)
                             {

--- a/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
+++ b/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
@@ -86,7 +86,18 @@ namespace LibUsbDotNet.Generator
                     switch (pointee.Kind)
                     {
                         case TypeKind.Pointer:
-                            return "ref IntPtr";
+                            // Double pointers are usually linked lists
+                            var listType = pointee.GetPointeeType();
+
+                            if (listType.Kind == TypeKind.Elaborated)
+                            {
+                                var pointee2Spelling = listType.GetNamedType().GetSpelling();
+                                return $"{NameConversions.ToClrName(pointee2Spelling, NameConversion.Type)}**";
+                            }
+                            else
+                            {
+                                return "ref IntPtr";
+                            }
 
                         case TypeKind.Int:
                             return "ref int";

--- a/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
+++ b/src/LibUsbDotNet.Generator/CXTypeKindExtensions.cs
@@ -132,9 +132,13 @@ namespace LibUsbDotNet.Generator
                             {
                                 return "ref UnixNativeTimeval";
                             }
+                            else if (spelling == "libusb_context")
+                            {
+                                return "ref Context";
+                            }
                             else
                             {
-                                return $"ref {NameConversions.ToClrName(spelling, NameConversion.Type)}";
+                                return $"{NameConversions.ToClrName(spelling, NameConversion.Type)}*";
                             }
 
                         default:

--- a/src/LibUsbDotNet.Generator/Delegate.cs.template
+++ b/src/LibUsbDotNet.Generator/Delegate.cs.template
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate {{ReturnType}} {{Name}}({{#Arguments}}{{Type}} {{Name}}{{ArgumentSeparator Arguments . }}{{/Arguments}});
+    public unsafe delegate {{ReturnType}} {{Name}}({{#Arguments}}{{Type}} {{Name}}{{ArgumentSeparator Arguments . }}{{/Arguments}});
 }

--- a/src/LibUsbDotNet.Generator/NativeMethods.cs.template
+++ b/src/LibUsbDotNet.Generator/NativeMethods.cs.template
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
-    internal static partial class NativeMethods
+    internal static unsafe partial class NativeMethods
     {
 #if WIN || NET45 || WIN7_X64 // win7-x64 during testing only.
         internal const string LibUsbNativeLibrary = "libusb-1.0.dll";

--- a/src/LibUsbDotNet.Generator/NativeMethods.cs.template
+++ b/src/LibUsbDotNet.Generator/NativeMethods.cs.template
@@ -37,6 +37,11 @@ namespace LibUsbDotNet
 {
     internal static unsafe partial class NativeMethods
     {
+        /// <summary>
+        /// Use the default struct alignment for this platform.
+        /// </summary>
+        internal const int Pack = 0;
+
 #if WIN || NET45 || WIN7_X64 // win7-x64 during testing only.
         internal const string LibUsbNativeLibrary = "libusb-1.0.dll";
         internal const CallingConvention LibUsbCallingConvention = CallingConvention.StdCall;

--- a/src/LibUsbDotNet.Generator/Primitives/Field.cs
+++ b/src/LibUsbDotNet.Generator/Primitives/Field.cs
@@ -8,6 +8,7 @@ namespace LibUsbDotNet.Generator.Primitives
     {
         public string Name { get; set; }
         public string Type { get; set; }
+        public string Description { get; set; }
         public int? FixedLengthString { get; set; }
     }
 }

--- a/src/LibUsbDotNet.Generator/Primitives/Struct.cs
+++ b/src/LibUsbDotNet.Generator/Primitives/Struct.cs
@@ -9,6 +9,7 @@ namespace LibUsbDotNet.Generator.Primitives
     public class Struct : IPrimitive
     {
         public string Name { get; set; }
+        public string Description { get; set; }
         public Collection<Field> Fields { get; } = new Collection<Field>();
     }
 }

--- a/src/LibUsbDotNet.Generator/Primitives/Struct.cs
+++ b/src/LibUsbDotNet.Generator/Primitives/Struct.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace LibUsbDotNet.Generator.Primitives
 {
@@ -11,5 +12,19 @@ namespace LibUsbDotNet.Generator.Primitives
         public string Name { get; set; }
         public string Description { get; set; }
         public Collection<Field> Fields { get; } = new Collection<Field>();
+        public string ExtraKeywords
+        {
+            get
+            {
+                if (Fields.Any(f => f.FixedLengthString != null))
+                {
+                    return "unsafe ";
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+        }
     }
 }

--- a/src/LibUsbDotNet.Generator/Struct.cs.template
+++ b/src/LibUsbDotNet.Generator/Struct.cs.template
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     {{{ToXmlDoc Description "4" }}}
     /// </summary>
     {{/Description}}
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public {{ExtraKeywords}}struct {{Name}}
     {
         {{#Fields}}

--- a/src/LibUsbDotNet.Generator/Struct.cs.template
+++ b/src/LibUsbDotNet.Generator/Struct.cs.template
@@ -40,7 +40,7 @@ namespace LibUsbDotNet
     /// </summary>
     {{/Description}}
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    public struct {{Name}}
+    public {{ExtraKeywords}}struct {{Name}}
     {
         {{#Fields}}
         {{#Description}}
@@ -48,7 +48,12 @@ namespace LibUsbDotNet
         {{{ToXmlDoc Description "8" }}}
         /// </summary>
         {{/Description}}
+        {{#FixedLengthString}}
+        public fixed char {{Name}}[{{FixedLengthString}}];
+        {{/FixedLengthString}}
+        {{^FixedLengthString}}
         public {{Type}} {{Name}};
+        {{/FixedLengthString}}
 
         {{/Fields}}
     }

--- a/src/LibUsbDotNet.Generator/Struct.cs.template
+++ b/src/LibUsbDotNet.Generator/Struct.cs.template
@@ -34,11 +34,22 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    {{#Description}}
+    /// <summary>
+    {{{ToXmlDoc Description "4" }}}
+    /// </summary>
+    {{/Description}}
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct {{Name}}
     {
         {{#Fields}}
+        {{#Description}}
+        /// <summary>
+        {{{ToXmlDoc Description "8" }}}
+        /// </summary>
+        {{/Description}}
         public {{Type}} {{Name}};
+
         {{/Fields}}
     }
 }

--- a/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
+++ b/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibUsbDotNet.Tests/MonoLibUsbTests.cs
+++ b/src/LibUsbDotNet.Tests/MonoLibUsbTests.cs
@@ -31,10 +31,10 @@ namespace MonoLibUsb.Tests
         }
 
         [Fact]
-        public void GetVersion()
+        public unsafe void GetVersion()
         {
             var version = NativeMethods.GetVersion();
-            Assert.Equal(1, version.Major);
+            Assert.Equal(1, version->Major);
         }
 
         [Fact]

--- a/src/LibUsbDotNet/Generated/BosDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  This descriptor is documented in section 9.6.2 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct BosDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/BosDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDescriptor.cs
@@ -64,5 +64,10 @@ namespace LibUsbDotNet
         /// </summary>
         public byte NumDeviceCaps;
 
+        /// <summary>
+        ///  bNumDeviceCap Device Capability Descriptors
+        /// </summary>
+        public IntPtr DevCapability;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/BosDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDescriptor.cs
@@ -34,12 +34,35 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the Binary Device Object Store (BOS) descriptor.
+    ///  This descriptor is documented in section 9.6.2 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct BosDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Length of this descriptor and all of its sub descriptors
+        /// </summary>
         public ushort TotalLength;
+
+        /// <summary>
+        ///  The number of separate device capability descriptors in
+        ///  the BOS
+        /// </summary>
         public byte NumDeviceCaps;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  advised to check bDevCapabilityType and call the matching
     ///  libusb_get_*_descriptor function to get a structure fully matching the type.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct BosDevCapabilityDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
@@ -34,12 +34,34 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A generic representation of a BOS Device Capability descriptor. It is
+    ///  advised to check bDevCapabilityType and call the matching
+    ///  libusb_get_*_descriptor function to get a structure fully matching the type.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct BosDevCapabilityDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  LIBUSB_DT_DEVICE_CAPABILITY in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Device Capability type
+        /// </summary>
         public byte DevCapabilityType;
+
+        /// <summary>
+        ///  Device Capability data (bLength - 3 bytes)
+        /// </summary>
         public string DevCapabilityData;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/BosDevCapabilityDescriptor.cs
@@ -61,7 +61,7 @@ namespace LibUsbDotNet
         /// <summary>
         ///  Device Capability data (bLength - 3 bytes)
         /// </summary>
-        public string DevCapabilityData;
+        public IntPtr DevCapabilityData;
 
     }
 }

--- a/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  descriptor is documented in section 9.6.3 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct ConfigDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ConfigDescriptor.cs
@@ -34,19 +34,74 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the standard USB configuration descriptor. This
+    ///  descriptor is documented in section 9.6.3 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct ConfigDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Total length of data returned for this configuration
+        /// </summary>
         public ushort TotalLength;
+
+        /// <summary>
+        ///  Number of interfaces supported by this configuration
+        /// </summary>
         public byte NumInterfaces;
+
+        /// <summary>
+        ///  Identifier value for this configuration
+        /// </summary>
         public byte ConfigurationValue;
+
+        /// <summary>
+        ///  Index of string descriptor describing this configuration
+        /// </summary>
         public byte Configuration;
+
+        /// <summary>
+        ///  Configuration characteristics
+        /// </summary>
         public byte Attributes;
+
+        /// <summary>
+        ///  Maximum power consumption of the USB device from this bus in this
+        ///  configuration when the device is fully operation. Expressed in units
+        ///  of 2 mA when the device is operating in high-speed mode and in units
+        ///  of 8 mA when the device is operating in super-speed mode.
+        /// </summary>
         public byte MaxPower;
+
+        /// <summary>
+        ///  Array of interfaces supported by this configuration. The length of
+        ///  this array is determined by the bNumInterfaces field.
+        /// </summary>
         public IntPtr Interface;
+
+        /// <summary>
+        ///  Extra descriptors. If libusb encounters unknown configuration
+        ///  descriptors, it will store them here, should you wish to parse them.
+        /// </summary>
         public IntPtr Extra;
+
+        /// <summary>
+        ///  Length of the extra descriptors, in bytes.
+        /// </summary>
         public int ExtraLength;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
@@ -40,7 +40,7 @@ namespace LibUsbDotNet
     ///  All multiple-byte fields, except UUIDs, are represented in host-endian format.
     /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
-    public struct ContainerIdDescriptor
+    public unsafe struct ContainerIdDescriptor
     {
         /// <summary>
         ///  Size of this descriptor (in bytes)
@@ -67,7 +67,7 @@ namespace LibUsbDotNet
         /// <summary>
         ///  128 bit UUID
         /// </summary>
-        public string ContainerID;
+        public fixed char ContainerID[16];
 
     }
 }

--- a/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
@@ -34,13 +34,40 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the Container ID descriptor.
+    ///  This descriptor is documented in section 9.6.2.3 of the USB 3.0 specification.
+    ///  All multiple-byte fields, except UUIDs, are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct ContainerIdDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  LIBUSB_DT_DEVICE_CAPABILITY in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Capability type. Will have value
+        ///  LIBUSB_BT_CONTAINER_ID in this context.
+        /// </summary>
         public byte DevCapabilityType;
+
+        /// <summary>
+        ///  Reserved field
+        /// </summary>
         public byte Reserved;
+
+        /// <summary>
+        ///  128 bit UUID
+        /// </summary>
         public string ContainerID;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/ContainerIdDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  This descriptor is documented in section 9.6.2.3 of the USB 3.0 specification.
     ///  All multiple-byte fields, except UUIDs, are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public unsafe struct ContainerIdDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/ControlSetup.cs
+++ b/src/LibUsbDotNet/Generated/ControlSetup.cs
@@ -37,7 +37,7 @@ namespace LibUsbDotNet
     /// <summary>
     ///  Setup packet for control transfers.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct ControlSetup
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/ControlSetup.cs
+++ b/src/LibUsbDotNet/Generated/ControlSetup.cs
@@ -34,13 +34,39 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  Setup packet for control transfers.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct ControlSetup
     {
+        /// <summary>
+        ///  Request type. Bits 0:4 determine recipient, see
+        /// </summary>
         public byte RequestType;
+
+        /// <summary>
+        ///  Request. If the type bits of bmRequestType are equal to
+        ///  "LIBUSB_REQUEST_TYPE_STANDARD" then this field refers to
+        ///  application-specific.
+        /// </summary>
         public byte Request;
+
+        /// <summary>
+        ///  Value. Varies according to request
+        /// </summary>
         public ushort Value;
+
+        /// <summary>
+        ///  Index. Varies according to request, typically used to pass an index
+        ///  or offset
+        /// </summary>
         public ushort Index;
+
+        /// <summary>
+        ///  Number of bytes to transfer
+        /// </summary>
         public ushort Length;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  descriptor is documented in section 9.6.1 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct DeviceDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/DeviceDescriptor.cs
@@ -34,22 +34,87 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the standard USB device descriptor. This
+    ///  descriptor is documented in section 9.6.1 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct DeviceDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  USB specification release number in binary-coded decimal. A value of
+        ///  0x0200 indicates USB 2.0, 0x0110 indicates USB 1.1, etc.
+        /// </summary>
         public ushort USB;
+
+        /// <summary>
+        ///  USB-IF class code for the device. See
+        /// </summary>
         public byte DeviceClass;
+
+        /// <summary>
+        ///  USB-IF subclass code for the device, qualified by the bDeviceClass
+        ///  value
+        /// </summary>
         public byte DeviceSubClass;
+
+        /// <summary>
+        ///  USB-IF protocol code for the device, qualified by the bDeviceClass and
+        ///  bDeviceSubClass values
+        /// </summary>
         public byte DeviceProtocol;
+
+        /// <summary>
+        ///  Maximum packet size for endpoint 0
+        /// </summary>
         public byte MaxPacketSize0;
+
+        /// <summary>
+        ///  USB-IF vendor ID
+        /// </summary>
         public ushort IdVendor;
+
+        /// <summary>
+        ///  USB-IF product ID
+        /// </summary>
         public ushort IdProduct;
+
+        /// <summary>
+        ///  Device release number in binary-coded decimal
+        /// </summary>
         public ushort Device;
+
+        /// <summary>
+        ///  Index of string descriptor describing manufacturer
+        /// </summary>
         public byte Manufacturer;
+
+        /// <summary>
+        ///  Index of string descriptor describing product
+        /// </summary>
         public byte Product;
+
+        /// <summary>
+        ///  Index of string descriptor containing device serial number
+        /// </summary>
         public byte SerialNumber;
+
+        /// <summary>
+        ///  Number of possible configurations
+        /// </summary>
         public byte NumConfigurations;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  descriptor is documented in section 9.6.6 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct EndpointDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/EndpointDescriptor.cs
@@ -34,18 +34,72 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the standard USB endpoint descriptor. This
+    ///  descriptor is documented in section 9.6.6 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct EndpointDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  The address of the endpoint described by this descriptor. Bits 0:3 are
+        ///  the endpoint number. Bits 4:6 are reserved. Bit 7 indicates direction,
+        ///  see
+        /// </summary>
         public byte EndpointAddress;
+
+        /// <summary>
+        ///  Attributes which apply to the endpoint when it is configured using
+        ///  the bConfigurationValue. Bits 0:1 determine the transfer type and
+        ///  correspond to
+        ///  isochronous endpoints and correspond to
+        ///  Bits 4:5 are also only used for isochronous endpoints and correspond to
+        /// </summary>
         public byte Attributes;
+
+        /// <summary>
+        ///  Maximum packet size this endpoint is capable of sending/receiving.
+        /// </summary>
         public ushort MaxPacketSize;
+
+        /// <summary>
+        ///  Interval for polling endpoint for data transfers.
+        /// </summary>
         public byte Interval;
+
+        /// <summary>
+        ///  For audio devices only: the rate at which synchronization feedback
+        ///  is provided.
+        /// </summary>
         public byte Refresh;
+
+        /// <summary>
+        ///  For audio devices only: the address if the synch endpoint
+        /// </summary>
         public byte SynchAddress;
+
+        /// <summary>
+        ///  Extra descriptors. If libusb encounters unknown endpoint descriptors,
+        ///  it will store them here, should you wish to parse them.
+        /// </summary>
         public IntPtr Extra;
+
+        /// <summary>
+        ///  Length of the extra descriptors, in bytes.
+        /// </summary>
         public int ExtraLength;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/HotplugCallbackFn.cs
+++ b/src/LibUsbDotNet/Generated/HotplugCallbackFn.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate int HotplugCallbackFn(Context ctx, Device device, HotplugEvent @event, IntPtr userData);
+    public unsafe delegate int HotplugCallbackFn(Context ctx, Device device, HotplugEvent @event, IntPtr userData);
 }

--- a/src/LibUsbDotNet/Generated/Interface.cs
+++ b/src/LibUsbDotNet/Generated/Interface.cs
@@ -37,7 +37,7 @@ namespace LibUsbDotNet
     /// <summary>
     ///  A collection of alternate settings for a particular USB interface.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct Interface
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/Interface.cs
+++ b/src/LibUsbDotNet/Generated/Interface.cs
@@ -34,10 +34,22 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A collection of alternate settings for a particular USB interface.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct Interface
     {
+        /// <summary>
+        ///  Array of interface descriptors. The length of this array is determined
+        ///  by the num_altsetting field.
+        /// </summary>
         public IntPtr Altsetting;
+
+        /// <summary>
+        ///  The number of alternate settings that belong to this interface
+        /// </summary>
         public int NumAltsetting;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  descriptor is documented in section 9.6.5 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct InterfaceDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/InterfaceDescriptor.cs
@@ -34,20 +34,79 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the standard USB interface descriptor. This
+    ///  descriptor is documented in section 9.6.5 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct InterfaceDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Number of this interface
+        /// </summary>
         public byte InterfaceNumber;
+
+        /// <summary>
+        ///  Value used to select this alternate setting for this interface
+        /// </summary>
         public byte AlternateSetting;
+
+        /// <summary>
+        ///  Number of endpoints used by this interface (excluding the control
+        ///  endpoint).
+        /// </summary>
         public byte NumEndpoints;
+
+        /// <summary>
+        ///  USB-IF class code for this interface. See
+        /// </summary>
         public byte InterfaceClass;
+
+        /// <summary>
+        ///  USB-IF subclass code for this interface, qualified by the
+        ///  bInterfaceClass value
+        /// </summary>
         public byte InterfaceSubClass;
+
+        /// <summary>
+        ///  USB-IF protocol code for this interface, qualified by the
+        ///  bInterfaceClass and bInterfaceSubClass values
+        /// </summary>
         public byte InterfaceProtocol;
+
+        /// <summary>
+        ///  Index of string descriptor describing this interface
+        /// </summary>
         public byte Interface;
+
+        /// <summary>
+        ///  Array of endpoint descriptors. This length of this array is determined
+        ///  by the bNumEndpoints field.
+        /// </summary>
         public IntPtr Endpoint;
+
+        /// <summary>
+        ///  Extra descriptors. If libusb encounters unknown interface descriptors,
+        ///  it will store them here, should you wish to parse them.
+        /// </summary>
         public IntPtr Extra;
+
+        /// <summary>
+        ///  Length of the extra descriptors, in bytes.
+        /// </summary>
         public int ExtraLength;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
@@ -37,7 +37,7 @@ namespace LibUsbDotNet
     /// <summary>
     ///  Isochronous packet descriptor.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct IsoPacketDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/IsoPacketDescriptor.cs
@@ -34,11 +34,26 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  Isochronous packet descriptor.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct IsoPacketDescriptor
     {
+        /// <summary>
+        ///  Length of data to request in this packet
+        /// </summary>
         public uint Length;
+
+        /// <summary>
+        ///  Amount of data that was actually transferred
+        /// </summary>
         public uint ActualLength;
+
+        /// <summary>
+        ///  Status code for this packet
+        /// </summary>
         public TransferStatus Status;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/NativeMethods.cs
+++ b/src/LibUsbDotNet/Generated/NativeMethods.cs
@@ -37,6 +37,11 @@ namespace LibUsbDotNet
 {
     internal static unsafe partial class NativeMethods
     {
+        /// <summary>
+        /// Use the default struct alignment for this platform.
+        /// </summary>
+        internal const int Pack = 0;
+
 #if WIN || NET45 || WIN7_X64 // win7-x64 during testing only.
         internal const string LibUsbNativeLibrary = "libusb-1.0.dll";
         internal const CallingConvention LibUsbCallingConvention = CallingConvention.StdCall;
@@ -141,10 +146,10 @@ namespace LibUsbDotNet
         public static extern byte GetPortNumber(Device dev);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_port_numbers")]
-        public static extern Error GetPortNumbers(Device dev, ref byte portNumbers, int portNumbersLen);
+        public static extern Error GetPortNumbers(Device dev, byte* portNumbers, int portNumbersLen);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_port_path")]
-        public static extern Error GetPortPath(Context ctx, Device dev, ref byte path, byte pathLength);
+        public static extern Error GetPortPath(Context ctx, Device dev, byte* path, byte pathLength);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_parent")]
         public static extern Device GetParent(Device dev);

--- a/src/LibUsbDotNet/Generated/NativeMethods.cs
+++ b/src/LibUsbDotNet/Generated/NativeMethods.cs
@@ -60,7 +60,7 @@ namespace LibUsbDotNet
         public static extern void SetDebug(Context ctx, int level);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_version")]
-        public static extern ref Version GetVersion();
+        public static extern Version* GetVersion();
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_has_capability")]
         public static extern int HasCapability(uint capability);
@@ -90,7 +90,7 @@ namespace LibUsbDotNet
         public static extern Error GetConfiguration(DeviceHandle dev, ref int config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_device_descriptor")]
-        public static extern Error GetDeviceDescriptor(Device dev, ref DeviceDescriptor desc);
+        public static extern Error GetDeviceDescriptor(Device dev, DeviceDescriptor* desc);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_active_config_descriptor")]
         public static extern Error GetActiveConfigDescriptor(Device dev, ConfigDescriptor** config);
@@ -102,37 +102,37 @@ namespace LibUsbDotNet
         public static extern Error GetConfigDescriptorByValue(Device dev, byte bconfigurationvalue, ConfigDescriptor** config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_config_descriptor")]
-        public static extern void FreeConfigDescriptor(ref ConfigDescriptor config);
+        public static extern void FreeConfigDescriptor(ConfigDescriptor* config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_endpoint_companion_descriptor")]
-        public static extern Error GetSsEndpointCompanionDescriptor(ref Context ctx, ref EndpointDescriptor endpoint, SsEndpointCompanionDescriptor** epComp);
+        public static extern Error GetSsEndpointCompanionDescriptor(ref Context ctx, EndpointDescriptor* endpoint, SsEndpointCompanionDescriptor** epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_endpoint_companion_descriptor")]
-        public static extern void FreeSsEndpointCompanionDescriptor(ref SsEndpointCompanionDescriptor epComp);
+        public static extern void FreeSsEndpointCompanionDescriptor(SsEndpointCompanionDescriptor* epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_bos_descriptor")]
         public static extern Error GetBosDescriptor(DeviceHandle devHandle, BosDescriptor** bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_bos_descriptor")]
-        public static extern void FreeBosDescriptor(ref BosDescriptor bos);
+        public static extern void FreeBosDescriptor(BosDescriptor* bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_usb_2_0_extension_descriptor")]
-        public static extern Error GetUsb20ExtensionDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, Usb20ExtensionDescriptor** usb20Extension);
+        public static extern Error GetUsb20ExtensionDescriptor(ref Context ctx, BosDevCapabilityDescriptor* devCap, Usb20ExtensionDescriptor** usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_usb_2_0_extension_descriptor")]
-        public static extern void FreeUsb20ExtensionDescriptor(ref Usb20ExtensionDescriptor usb20Extension);
+        public static extern void FreeUsb20ExtensionDescriptor(Usb20ExtensionDescriptor* usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_usb_device_capability_descriptor")]
-        public static extern Error GetSsUsbDeviceCapabilityDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, SsUsbDeviceCapabilityDescriptor** ssUsbDeviceCap);
+        public static extern Error GetSsUsbDeviceCapabilityDescriptor(ref Context ctx, BosDevCapabilityDescriptor* devCap, SsUsbDeviceCapabilityDescriptor** ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_usb_device_capability_descriptor")]
-        public static extern void FreeSsUsbDeviceCapabilityDescriptor(ref SsUsbDeviceCapabilityDescriptor ssUsbDeviceCap);
+        public static extern void FreeSsUsbDeviceCapabilityDescriptor(SsUsbDeviceCapabilityDescriptor* ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_container_id_descriptor")]
-        public static extern Error GetContainerIdDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ContainerIdDescriptor** containerId);
+        public static extern Error GetContainerIdDescriptor(ref Context ctx, BosDevCapabilityDescriptor* devCap, ContainerIdDescriptor** containerId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_container_id_descriptor")]
-        public static extern void FreeContainerIdDescriptor(ref ContainerIdDescriptor containerId);
+        public static extern void FreeContainerIdDescriptor(ContainerIdDescriptor* containerId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_bus_number")]
         public static extern byte GetBusNumber(Device dev);
@@ -216,22 +216,22 @@ namespace LibUsbDotNet
         public static extern Error SetAutoDetachKernelDriver(DeviceHandle devHandle, int enable);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_alloc_transfer")]
-        public static extern ref Transfer AllocTransfer(int isoPackets);
+        public static extern Transfer* AllocTransfer(int isoPackets);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_submit_transfer")]
-        public static extern Error SubmitTransfer(ref Transfer transfer);
+        public static extern Error SubmitTransfer(Transfer* transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_cancel_transfer")]
-        public static extern Error CancelTransfer(ref Transfer transfer);
+        public static extern Error CancelTransfer(Transfer* transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_transfer")]
-        public static extern void FreeTransfer(ref Transfer transfer);
+        public static extern void FreeTransfer(Transfer* transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_transfer_set_stream_id")]
-        public static extern void TransferSetStreamId(ref Transfer transfer, uint streamId);
+        public static extern void TransferSetStreamId(Transfer* transfer, uint streamId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_transfer_get_stream_id")]
-        public static extern uint TransferGetStreamId(ref Transfer transfer);
+        public static extern uint TransferGetStreamId(Transfer* transfer);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_control_transfer")]
         public static extern int ControlTransfer(DeviceHandle devHandle, byte requestType, byte brequest, ushort wvalue, ushort windex, IntPtr data, ushort wlength, uint timeout);

--- a/src/LibUsbDotNet/Generated/NativeMethods.cs
+++ b/src/LibUsbDotNet/Generated/NativeMethods.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
-    internal static partial class NativeMethods
+    internal static unsafe partial class NativeMethods
     {
 #if WIN || NET45 || WIN7_X64 // win7-x64 during testing only.
         internal const string LibUsbNativeLibrary = "libusb-1.0.dll";
@@ -93,43 +93,43 @@ namespace LibUsbDotNet
         public static extern Error GetDeviceDescriptor(Device dev, ref DeviceDescriptor desc);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_active_config_descriptor")]
-        public static extern Error GetActiveConfigDescriptor(Device dev, ref IntPtr config);
+        public static extern Error GetActiveConfigDescriptor(Device dev, ConfigDescriptor** config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_config_descriptor")]
-        public static extern Error GetConfigDescriptor(Device dev, byte configIndex, ref IntPtr config);
+        public static extern Error GetConfigDescriptor(Device dev, byte configIndex, ConfigDescriptor** config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_config_descriptor_by_value")]
-        public static extern Error GetConfigDescriptorByValue(Device dev, byte bconfigurationvalue, ref IntPtr config);
+        public static extern Error GetConfigDescriptorByValue(Device dev, byte bconfigurationvalue, ConfigDescriptor** config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_config_descriptor")]
         public static extern void FreeConfigDescriptor(ref ConfigDescriptor config);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_endpoint_companion_descriptor")]
-        public static extern Error GetSsEndpointCompanionDescriptor(ref Context ctx, ref EndpointDescriptor endpoint, ref IntPtr epComp);
+        public static extern Error GetSsEndpointCompanionDescriptor(ref Context ctx, ref EndpointDescriptor endpoint, SsEndpointCompanionDescriptor** epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_endpoint_companion_descriptor")]
         public static extern void FreeSsEndpointCompanionDescriptor(ref SsEndpointCompanionDescriptor epComp);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_bos_descriptor")]
-        public static extern Error GetBosDescriptor(DeviceHandle devHandle, ref IntPtr bos);
+        public static extern Error GetBosDescriptor(DeviceHandle devHandle, BosDescriptor** bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_bos_descriptor")]
         public static extern void FreeBosDescriptor(ref BosDescriptor bos);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_usb_2_0_extension_descriptor")]
-        public static extern Error GetUsb20ExtensionDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr usb20Extension);
+        public static extern Error GetUsb20ExtensionDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, Usb20ExtensionDescriptor** usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_usb_2_0_extension_descriptor")]
         public static extern void FreeUsb20ExtensionDescriptor(ref Usb20ExtensionDescriptor usb20Extension);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_ss_usb_device_capability_descriptor")]
-        public static extern Error GetSsUsbDeviceCapabilityDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr ssUsbDeviceCap);
+        public static extern Error GetSsUsbDeviceCapabilityDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, SsUsbDeviceCapabilityDescriptor** ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_ss_usb_device_capability_descriptor")]
         public static extern void FreeSsUsbDeviceCapabilityDescriptor(ref SsUsbDeviceCapabilityDescriptor ssUsbDeviceCap);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_container_id_descriptor")]
-        public static extern Error GetContainerIdDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ref IntPtr containerId);
+        public static extern Error GetContainerIdDescriptor(ref Context ctx, ref BosDevCapabilityDescriptor devCap, ContainerIdDescriptor** containerId);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_container_id_descriptor")]
         public static extern void FreeContainerIdDescriptor(ref ContainerIdDescriptor containerId);
@@ -294,10 +294,10 @@ namespace LibUsbDotNet
         public static extern Error GetNextTimeout(Context ctx, ref UnixNativeTimeval tv);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_get_pollfds")]
-        public static extern ref IntPtr GetPollfds(Context ctx);
+        public static extern Pollfd** GetPollfds(Context ctx);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_free_pollfds")]
-        public static extern void FreePollfds(ref IntPtr pollfds);
+        public static extern void FreePollfds(Pollfd** pollfds);
 
         [DllImport(LibUsbNativeLibrary, CallingConvention = LibUsbCallingConvention, EntryPoint = "libusb_set_pollfd_notifiers")]
         public static extern void SetPollfdNotifiers(Context ctx, IntPtr addedDelegate, IntPtr removedDelegate, IntPtr userData);

--- a/src/LibUsbDotNet/Generated/Pollfd.cs
+++ b/src/LibUsbDotNet/Generated/Pollfd.cs
@@ -37,7 +37,7 @@ namespace LibUsbDotNet
     /// <summary>
     ///  File descriptor for polling
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct Pollfd
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/Pollfd.cs
+++ b/src/LibUsbDotNet/Generated/Pollfd.cs
@@ -34,10 +34,26 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  File descriptor for polling
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct Pollfd
     {
+        /// <summary>
+        ///  Numeric file descriptor
+        /// </summary>
         public int Fd;
+
+        /// <summary>
+        ///  Event flags to poll for from
+        ///  <poll
+        ///  .h>. POLLIN indicates that you
+        ///  should monitor this file descriptor for becoming ready to read from,
+        ///  and POLLOUT indicates that you should monitor this file descriptor for
+        ///  nonblocking write readiness.
+        /// </summary>
         public short Events;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/PollfdAddedDelegate.cs
+++ b/src/LibUsbDotNet/Generated/PollfdAddedDelegate.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate void PollfdAddedDelegate(int fd, short events, IntPtr userData);
+    public unsafe delegate void PollfdAddedDelegate(int fd, short events, IntPtr userData);
 }

--- a/src/LibUsbDotNet/Generated/PollfdRemovedDelegate.cs
+++ b/src/LibUsbDotNet/Generated/PollfdRemovedDelegate.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate void PollfdRemovedDelegate(int fd, IntPtr userData);
+    public unsafe delegate void PollfdRemovedDelegate(int fd, IntPtr userData);
 }

--- a/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
@@ -34,13 +34,45 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the superspeed endpoint companion
+    ///  descriptor. This descriptor is documented in section 9.6.7 of
+    ///  the USB 3.0 specification. All multiple-byte fields are represented in
+    ///  host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct SsEndpointCompanionDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  The maximum number of packets the endpoint can send or
+        ///  receive as part of a burst.
+        /// </summary>
         public byte MaxBurst;
+
+        /// <summary>
+        ///  In bulk EP:	bits 4:0 represents the	maximum	number of
+        ///  streams the	EP supports. In	isochronous EP:	bits 1:0
+        ///  represents the Mult	- a zero based value that determines
+        ///  the	maximum	number of packets within a service interval
+        /// </summary>
         public byte Attributes;
+
+        /// <summary>
+        ///  The	total number of bytes this EP will transfer every
+        ///  service interval. valid only for periodic EPs.
+        /// </summary>
         public ushort BytesPerInterval;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsEndpointCompanionDescriptor.cs
@@ -40,7 +40,7 @@ namespace LibUsbDotNet
     ///  the USB 3.0 specification. All multiple-byte fields are represented in
     ///  host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct SsEndpointCompanionDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  This descriptor is documented in section 9.6.2.2 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct SsUsbDeviceCapabilityDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/SsUsbDeviceCapabilityDescriptor.cs
@@ -34,16 +34,62 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the SuperSpeed USB Device Capability descriptor
+    ///  This descriptor is documented in section 9.6.2.2 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct SsUsbDeviceCapabilityDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  LIBUSB_DT_DEVICE_CAPABILITY in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Capability type. Will have value
+        ///  LIBUSB_BT_SS_USB_DEVICE_CAPABILITY in this context.
+        /// </summary>
         public byte DevCapabilityType;
+
+        /// <summary>
+        ///  Bitmap encoding of supported device level features.
+        ///  A value of one in a bit location indicates a feature is
+        ///  supported; a value of zero indicates it is not supported.
+        ///  See
+        /// </summary>
         public byte Attributes;
+
+        /// <summary>
+        ///  Bitmap encoding of the speed supported by this device when
+        ///  operating in SuperSpeed mode. See
+        /// </summary>
         public ushort SpeedSupported;
+
+        /// <summary>
+        ///  The lowest speed at which all the functionality supported
+        ///  by the device is available to the user. For example if the
+        ///  device supports all its functionality when connected at
+        ///  full speed and above then it sets this value to 1.
+        /// </summary>
         public byte FunctionalitySupport;
+
+        /// <summary>
+        ///  U1 Device Exit Latency.
+        /// </summary>
         public byte U1DevExitLat;
+
+        /// <summary>
+        ///  U2 Device Exit Latency.
+        /// </summary>
         public ushort U2DevExitLat;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/Transfer.cs
+++ b/src/LibUsbDotNet/Generated/Transfer.cs
@@ -34,6 +34,12 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  The generic USB transfer structure. The user populates this structure and
+    ///  then submits it in order to request a transfer. After the transfer has
+    ///  completed, the library populates the transfer with the results and passes
+    ///  it back to the user.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct Transfer
     {

--- a/src/LibUsbDotNet/Generated/Transfer.cs
+++ b/src/LibUsbDotNet/Generated/Transfer.cs
@@ -40,7 +40,7 @@ namespace LibUsbDotNet
     ///  completed, the library populates the transfer with the results and passes
     ///  it back to the user.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct Transfer
     {
     }

--- a/src/LibUsbDotNet/Generated/TransferDelegate.cs
+++ b/src/LibUsbDotNet/Generated/TransferDelegate.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 namespace LibUsbDotNet
 {
     [UnmanagedFunctionPointer(NativeMethods.LibUsbCallingConvention)]
-    public delegate void TransferDelegate(ref Transfer transfer);
+    public unsafe delegate void TransferDelegate(Transfer* transfer);
 }

--- a/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet
     ///  This descriptor is documented in section 9.6.2.1 of the USB 3.0 specification.
     ///  All multiple-byte fields are represented in host-endian format.
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct Usb20ExtensionDescriptor
     {
         /// <summary>

--- a/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
+++ b/src/LibUsbDotNet/Generated/Usb20ExtensionDescriptor.cs
@@ -34,12 +34,38 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  A structure representing the USB 2.0 Extension descriptor
+    ///  This descriptor is documented in section 9.6.2.1 of the USB 3.0 specification.
+    ///  All multiple-byte fields are represented in host-endian format.
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct Usb20ExtensionDescriptor
     {
+        /// <summary>
+        ///  Size of this descriptor (in bytes)
+        /// </summary>
         public byte Length;
+
+        /// <summary>
+        ///  Descriptor type. Will have value
+        ///  LIBUSB_DT_DEVICE_CAPABILITY in this context.
+        /// </summary>
         public byte DescriptorType;
+
+        /// <summary>
+        ///  Capability type. Will have value
+        ///  LIBUSB_BT_USB_2_0_EXTENSION in this context.
+        /// </summary>
         public byte DevCapabilityType;
+
+        /// <summary>
+        ///  Bitmap encoding of supported device level features.
+        ///  A value of one in a bit location indicates a feature is
+        ///  supported; a value of zero indicates it is not supported.
+        ///  See
+        /// </summary>
         public uint Attributes;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/Version.cs
+++ b/src/LibUsbDotNet/Generated/Version.cs
@@ -34,14 +34,41 @@ using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet
 {
+    /// <summary>
+    ///  Structure providing the version of the libusb runtime
+    /// </summary>
     [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
     public struct Version
     {
+        /// <summary>
+        ///  Library major version.
+        /// </summary>
         public ushort Major;
+
+        /// <summary>
+        ///  Library minor version.
+        /// </summary>
         public ushort Minor;
+
+        /// <summary>
+        ///  Library micro version.
+        /// </summary>
         public ushort Micro;
+
+        /// <summary>
+        ///  Library nano version.
+        /// </summary>
         public ushort Nano;
+
+        /// <summary>
+        ///  Library release candidate suffix string, e.g. "-rc4".
+        /// </summary>
         public IntPtr Rc;
+
+        /// <summary>
+        ///  For ABI compatibility only.
+        /// </summary>
         public IntPtr Describe;
+
     }
 }

--- a/src/LibUsbDotNet/Generated/Version.cs
+++ b/src/LibUsbDotNet/Generated/Version.cs
@@ -37,7 +37,7 @@ namespace LibUsbDotNet
     /// <summary>
     ///  Structure providing the version of the libusb runtime
     /// </summary>
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 1)]
+    [StructLayoutAttribute(LayoutKind.Sequential, Pack = NativeMethods.Pack)]
     public struct Version
     {
         /// <summary>

--- a/src/LibUsbDotNet/LibUsb/MonoLibUsbApiHelpers.cs
+++ b/src/LibUsbDotNet/LibUsb/MonoLibUsbApiHelpers.cs
@@ -400,10 +400,10 @@ namespace MonoLibUsb
         /// </remarks>
         /// <param name="sessionHandle">A valid <see cref="MonoUsbSessionHandle"/>.</param>
         /// <returns>A list of PollfdItem structures, or null on error.</returns>
-        public static List<PollfdItem> GetPollfds(Context sessionHandle)
+        public static unsafe List<PollfdItem> GetPollfds(Context sessionHandle)
         {
             List<PollfdItem> rtnList = new List<PollfdItem>();
-            IntPtr pList = NativeMethods.GetPollfds(sessionHandle);
+            IntPtr pList = new IntPtr(NativeMethods.GetPollfds(sessionHandle));
             if (pList == IntPtr.Zero) return null;
 
             IntPtr pNext = pList;

--- a/src/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/src/LibUsbDotNet/LibUsbDotNet.csproj
@@ -4,6 +4,7 @@
     <Description>.NET C# USB library for WinUSB, LibUsb-Win32, and libusb-1.0. Using the common device classes, applications work with all operating systems and drivers without modification. Lots of example code. Open source software at sourceforge.net.</Description>
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net45</TargetFrameworks>
     <RuntimeIdentifiers>win;linux;osx</RuntimeIdentifiers>


### PR DESCRIPTION
- Add XML documentation to the structs (as it's readily available in the C source code)
- Fix marshalling of fixed-length buffers
- Use pointers (which can be used using `unsafe` code in C#) where it makes sense
- Use the platform-default struct alignment