### PR TITLE
Bump libusb, libusbK builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  libusbBuild: 59 # 20180921.5
-  libusbkBuild: 84 # 20180921.5
+  libusbBuild: 155 # 20200309.1
+  libusbkBuild: 153 # 20200309.1
 
 jobs:
 - job: windows


### PR DESCRIPTION
The build was referencing outdated builds (which have since been removed), bump to newer versions.