### PR TITLE
Remove leftover reference to LibUsbDotNet.LibUsb

### DIFF
--- a/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
+++ b/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\LibUsbDotNet.LibUsb\LibUsbDotNet.LibUsb.csproj" />
     <ProjectReference Include="..\LibUsbDotNet\LibUsbDotNet.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #92 