### PR TITLE
Fix TryOpen, Dispose

### DIFF
--- a/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.cs
@@ -275,40 +275,13 @@ namespace LibUsbDotNet.LibUsb
         /// </summary>
         public void Open()
         {
-            this.EnsureNotDisposed();
-
-            if (this.IsOpen)
-            {
-                return;
-            }
-
-            IntPtr deviceHandle = IntPtr.Zero;
-            NativeMethods.Open(this.device, ref deviceHandle).ThrowOnError();
-
-            this.deviceHandle = DeviceHandle.DangerousCreate(deviceHandle);
-            this.descriptor = null;
+            this.OpenNative().ThrowOnError();
         }
 
         /// <inheritdoc/>
         public bool TryOpen()
         {
-            this.EnsureNotDisposed();
-
-            if (this.IsOpen)
-            {
-                return true;
-            }
-
-            IntPtr deviceHandle = IntPtr.Zero;
-            if (NativeMethods.Open(this.device, ref deviceHandle) == Error.Success)
-            {
-                this.deviceHandle = DeviceHandle.DangerousCreate(deviceHandle);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return this.OpenNative() == Error.Success;
         }
 
         /// <summary>
@@ -336,6 +309,27 @@ namespace LibUsbDotNet.LibUsb
             {
                 throw new UsbException("The device has not been opened. You need to call Open() first.");
             }
+        }
+
+        private Error OpenNative()
+        {
+            this.EnsureNotDisposed();
+
+            if (this.IsOpen)
+            {
+                return Error.Success;
+            }
+
+            IntPtr deviceHandle = IntPtr.Zero;
+            var ret = NativeMethods.Open(this.device, ref deviceHandle);
+            
+            if (ret == Error.Success)
+            {
+                this.deviceHandle = DeviceHandle.DangerousCreate(deviceHandle);
+                this.descriptor = null;
+            }
+
+            return ret;
         }
     }
 }

--- a/src/LibUsbDotNet/LibUsb/UsbDevice.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbDevice.cs
@@ -73,13 +73,17 @@ namespace LibUsbDotNet.LibUsb
         /// <inheritdoc/>
         public void Dispose()
         {
-            // Close the libusb_device_handle if required.
-            this.Close();
+            if (!this.disposed)
+            {
+                // Close the libusb_device_handle if required.
+                this.Close();
 
-            // Close the libusb_device handle.
-            this.device.Dispose();
+                // Close the libusb_device handle.
+                this.deviceHandle.Dispose();
+                this.device.Dispose();
 
-            this.disposed = true;
+                this.disposed = true;
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
- Share the same across `TryOpen` and `Open`, making sure the descriptor is reset when `Open` is called
- Make `Dispose` a no-op when `disposed == true`, making it re-entrant.