### PR TITLE
Fix a NullReferenceException in Dispose().

### DIFF
--- a/src/LibUsbDotNet/LibUsb/UsbDevice.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbDevice.cs
@@ -79,7 +79,6 @@ namespace LibUsbDotNet.LibUsb
                 this.Close();
 
                 // Close the libusb_device handle.
-                this.deviceHandle.Dispose();
                 this.device.Dispose();
 
                 this.disposed = true;


### PR DESCRIPTION
deviceHandle is owned by Open/Close, and should not be modified by Dipose()