### PR TITLE
UsbEndpoint*: Accept an IUsbDevice object

### DIFF
--- a/src/LibUsbDotNet/LibUsb/IUsbDevice.cs
+++ b/src/LibUsbDotNet/LibUsb/IUsbDevice.cs
@@ -36,6 +36,12 @@ namespace LibUsbDotNet.LibUsb
     public interface IUsbDevice : IDisposable
     {
         /// <summary>
+        /// Gets the underlying device handle. The handle is populated when you open the device
+        /// using <see cref="Open"/>, and cleared when you close the device using <see cref="Close"/>.
+        /// </summary>
+        DeviceHandle DeviceHandle { get; }
+
+        /// <summary>
         /// Gets the available configurations for this <see cref="UsbDevice"/>
         /// </summary>
         /// <remarks>

--- a/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.cs
@@ -35,7 +35,8 @@ namespace LibUsbDotNet.LibUsb
         /// </summary>
         private DeviceHandle deviceHandle;
 
-        internal DeviceHandle DeviceHandle
+        /// <inheritdoc/>
+        public DeviceHandle DeviceHandle
         {
             get { return this.deviceHandle; }
         }

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -31,13 +31,13 @@ namespace LibUsbDotNet.LibUsb
     public abstract class UsbEndpointBase
     {
         private readonly byte mEpNum;
-        private readonly UsbDevice mUsbDevice;
+        private readonly IUsbDevice mUsbDevice;
         private readonly byte alternateInterfaceID;
         private UsbEndpointInfo mUsbEndpointInfo;
         private EndpointType mEndpointType;
         private UsbInterfaceInfo mUsbInterfacetInfo;
 
-        internal UsbEndpointBase(UsbDevice usbDevice, byte alternateInterfaceID, byte epNum, EndpointType endpointType)
+        internal UsbEndpointBase(IUsbDevice usbDevice, byte alternateInterfaceID, byte epNum, EndpointType endpointType)
         {
             this.mUsbDevice = usbDevice;
             this.alternateInterfaceID = alternateInterfaceID;
@@ -48,7 +48,7 @@ namespace LibUsbDotNet.LibUsb
         /// <summary>
         /// Gets the <see cref="UsbDevice"/> class this endpoint belongs to.
         /// </summary>
-        public UsbDevice Device
+        public IUsbDevice Device
         {
             get { return this.mUsbDevice; }
         }

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
@@ -39,7 +39,7 @@ namespace LibUsbDotNet.LibUsb
     {
         private int mReadBufferSize;
 
-        public UsbEndpointReader(UsbDevice usbDevice, int readBufferSize, byte alternateInterfaceID, ReadEndpointID readEndpointID, EndpointType endpointType)
+        public UsbEndpointReader(IUsbDevice usbDevice, int readBufferSize, byte alternateInterfaceID, ReadEndpointID readEndpointID, EndpointType endpointType)
             : base(usbDevice, alternateInterfaceID, (byte)readEndpointID, endpointType)
         {
             this.mReadBufferSize = readBufferSize;

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
@@ -29,7 +29,7 @@ namespace LibUsbDotNet.LibUsb
     /// </summary>
     public class UsbEndpointWriter : UsbEndpointBase
     {
-        public UsbEndpointWriter(UsbDevice usbDevice, byte alternateInterfaceID, WriteEndpointID writeEndpointID, EndpointType endpointType)
+        public UsbEndpointWriter(IUsbDevice usbDevice, byte alternateInterfaceID, WriteEndpointID writeEndpointID, EndpointType endpointType)
             : base(usbDevice, alternateInterfaceID, (byte)writeEndpointID, endpointType)
         {
         }


### PR DESCRIPTION
Depend on the interface instead of the implementation, to make the coupling looser.