### PR TITLE
Fix Azure DevOps pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,28 +7,26 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: 'specific'
+      source: 'specific'
       project: 'libusbdotnet'
       pipeline: '2'
-      buildVersionToDownload: 'specific'
-      buildId: $(libusbBuild)
-      downloadType: 'single'
-      artifactName: 'drop'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      runVersion: 'specific'
+      runId: $(libusbBuild)
+      artifact: 'drop'
+      path: '$(System.ArtifactsDirectory)/drop'
     displayName: 'download libusb artifacts'
 
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: 'specific'
+      source: 'specific'
       project: 'libusbdotnet'
       pipeline: '3'
-      buildVersionToDownload: 'specific'
-      buildId: $(libusbkBuild)
-      downloadType: 'single'
-      artifactName: 'drop'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      runVersion: 'specific'
+      runId: $(libusbkBuild)
+      artifact: 'drop'
+      path: '$(System.ArtifactsDirectory)/drop'
     displayName: 'download libusbK artifacts'
 
   - script: |
@@ -56,16 +54,15 @@ jobs:
   pool:
     vmImage: 'macOS-10.15'
   steps:
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: 'specific'
+      source: 'specific'
       project: 'libusbdotnet'
       pipeline: '2'
-      buildVersionToDownload: 'specific'
-      buildId: $(libusbBuild)
-      downloadType: 'single'
-      artifactName: 'drop'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      runVersion: 'specific'
+      runId: $(libusbBuild)
+      artifact: 'drop'
+      path: '$(System.ArtifactsDirectory)/drop'
     displayName: 'download libusb artifacts'
 
   - script: |

--- a/src/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/src/LibUsbDotNet/LibUsbDotNet.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/refs/LibUsbDotNet.LibUsb.refs.csproj
+++ b/src/refs/LibUsbDotNet.LibUsb.refs.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use `DownloadPipelineArtifact@2` instead of `DownloadBuildArtifacts@0` to fix a build break
- Update to the latest version of NerdBank.GitVersioning to fix a build break