### PR TITLE
BenchmarkCon: Fix help text

### DIFF
--- a/stage/BenchmarkCon/BenchmarkCon.csproj
+++ b/stage/BenchmarkCon/BenchmarkCon.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="BenchmarkHelp.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\LibUsbDotNet\LibUsbDotNet.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
BenchmarkCon expects to read the help tesk from an embedded resource. Make sure BenchmarkHelp.txt is compiled into the assembly as an embedded resource.