### PR TITLE
UsbInterfaceInfo: Add extra bytes for descriptor

### DIFF
--- a/stage/LibUsbDotNet/Info/UsbInterfaceInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbInterfaceInfo.cs
@@ -48,6 +48,11 @@ namespace LibUsbDotNet.Info
         {
             mUsbDevice = usbDevice;
 
+            if (monoUSBAltInterfaceDescriptor.ExtraLength > 0)
+            {
+                this.mRawDescriptors.Add(monoUSBAltInterfaceDescriptor.ExtraBytes);
+            }
+
             mUsbInterfaceDescriptor = new UsbInterfaceDescriptor(monoUSBAltInterfaceDescriptor);
             List<MonoUsbEndpointDescriptor> monoUsbEndpoints = monoUSBAltInterfaceDescriptor.EndpointList;
             foreach (MonoUsbEndpointDescriptor monoUSBEndpoint in monoUsbEndpoints)


### PR DESCRIPTION
USB protocols like DFU provide extra bytes in descriptor -- pass the needed
information forward so application can utilize the information.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>