### PR TITLE
The project framework was upgraded to .NET 6 to add method calls for DetachKernelDriver and SetAutoDetachKernelDriver.

### DIFF
--- a/stage/Benchmark/Benchmark.csproj
+++ b/stage/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/stage/BenchmarkCon/BenchmarkCon.csproj
+++ b/stage/BenchmarkCon/BenchmarkCon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Directory.Build.props
+++ b/stage/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.205" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/stage/Examples/Device.Notification/Device.Notification.csproj
+++ b/stage/Examples/Device.Notification/Device.Notification.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Isochronous/Read.Isochronous.csproj
+++ b/stage/Examples/Read.Isochronous/Read.Isochronous.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Only/Read.Only.csproj
+++ b/stage/Examples/Read.Only/Read.Only.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Write.Async/Read.Write.Async.csproj
+++ b/stage/Examples/Read.Write.Async/Read.Write.Async.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Write.Event/Read.Write.Event.csproj
+++ b/stage/Examples/Read.Write.Event/Read.Write.Event.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Write/Read.Write.csproj
+++ b/stage/Examples/Read.Write/Read.Write.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/Examples/Read.Write/ReadWrite.cs
+++ b/stage/Examples/Read.Write/ReadWrite.cs
@@ -38,6 +38,17 @@ namespace Examples
                     // This is a "whole" USB device. Before it can be used, 
                     // the desired configuration and interface must be selected.
 
+                    if (Helper.IsLinux)
+                    {
+                        //If it is a Linux environment
+                        //you can execute DetachKernelDriver or SetAutoDetachKernelDriver
+
+                        wholeUsbDevice.SetAutoDetachKernelDriver(true);
+
+                        // detach kernel driver #0.
+                        wholeUsbDevice.DetachKernelDriver(0);
+                    }
+
                     // Select config #1
                     wholeUsbDevice.SetConfiguration(1);
 

--- a/stage/Examples/Show.Info/Show.Info.csproj
+++ b/stage/Examples/Show.Info/Show.Info.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stage/InfWizard/InfWizard.csproj
+++ b/stage/InfWizard/InfWizard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/stage/LibUsbDotNet/Descriptors/DescriptorType.cs
+++ b/stage/LibUsbDotNet/Descriptors/DescriptorType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/LangStringDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/LangStringDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/StringDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/StringDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/UsbConfigDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/UsbConfigDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/UsbDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/UsbDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/UsbDeviceDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/UsbDeviceDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+ï»¿// Copyright Â© 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -45,7 +45,7 @@ namespace LibUsbDotNet.Descriptors
 
         /// <summary>
         /// Class Code (Assigned by USB Org)
-        /// If equal to Zero, each interface specifies it’s own class code; If equal to 0xFF, the class code is vendor specified; Otherwise field is valid Class Code.
+        /// If equal to Zero, each interface specifies itâ€™s own class code; If equal to 0xFF, the class code is vendor specified; Otherwise field is valid Class Code.
         /// </summary>
         public ClassCodeType Class;
 

--- a/stage/LibUsbDotNet/Descriptors/UsbEndpointDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/UsbEndpointDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Descriptors/UsbInterfaceDescriptor.cs
+++ b/stage/LibUsbDotNet/Descriptors/UsbInterfaceDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/DeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/DeviceNotifier.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/DeviceNotifyEventArgs.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/DeviceNotifyEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/DeviceType.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/DeviceType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/EventType.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/EventType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/IDeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/IDeviceNotifier.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/IPortNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/IPortNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/IUsbDeviceNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/IUsbDeviceNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/IVolumeNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/IVolumeNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/PortNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/PortNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/UsbDeviceNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/UsbDeviceNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Info/VolumeNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Info/VolumeNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastDeviceinterface.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastDeviceinterface.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastHdr.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastHdr.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastPort.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastPort.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastVolume.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevBroadcastVolume.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/DevNotifyNativeWindow.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/DevNotifyNativeWindow.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -1,4 +1,4 @@
-﻿ļ»æ#if NETSTANDARD1_5 || NETSTANDARD1_6
+﻿#if  NETSTANDARD1_5 || NETSTANDARD1_6
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD1_5 || NETSTANDARD1_6
+﻿ļ»æ#if NETSTANDARD1_5 || NETSTANDARD1_6
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/stage/LibUsbDotNet/DeviceNotify/Internal/SafeNotifyHandle.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Internal/SafeNotifyHandle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDevItem.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDevItem.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDevItemList.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDevItemList.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifier.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifierMode.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxDeviceNotifierMode.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxUsbDeviceNotifyInfo.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/Linux/LinuxUsbDeviceNotifyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifier.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifier.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifyEventArgs.cs
+++ b/stage/LibUsbDotNet/DeviceNotify/WindowsDeviceNotifyEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/IUsbDevice.cs
+++ b/stage/LibUsbDotNet/IUsbDevice.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/IUsbDevice.cs
+++ b/stage/LibUsbDotNet/IUsbDevice.cs
@@ -42,14 +42,14 @@ namespace LibUsbDotNet
     public interface IUsbDevice : IUsbInterface
     {
         /// <summary>
-        /// Detach Kerne lDriver the specified interface of the device.
+        /// Detach Kernel Driver the specified interface of the device.
         /// </summary>
-        /// <param name="interfaceID">The interface to DetachKernelDriver.</param>
+        /// <param name="interfaceID">The interface to detach.</param>
         /// <returns>True on success.</returns>
         bool DetachKernelDriver(int interfaceID);
 
         /// <summary>
-        /// Set Auto Detach Kernel Driver
+        /// Enable/disable libusb's automatic kernel driver detachment.
         /// </summary>
         /// <param name="autoDetach"></param>
         /// <returns></returns>

--- a/stage/LibUsbDotNet/IUsbDevice.cs
+++ b/stage/LibUsbDotNet/IUsbDevice.cs
@@ -42,6 +42,19 @@ namespace LibUsbDotNet
     public interface IUsbDevice : IUsbInterface
     {
         /// <summary>
+        /// Detach Kerne lDriver the specified interface of the device.
+        /// </summary>
+        /// <param name="interfaceID">The interface to DetachKernelDriver.</param>
+        /// <returns>True on success.</returns>
+        bool DetachKernelDriver(int interfaceID);
+
+        /// <summary>
+        /// Set Auto Detach Kernel Driver
+        /// </summary>
+        /// <param name="autoDetach"></param>
+        /// <returns></returns>
+        bool SetAutoDetachKernelDriver(bool autoDetach);
+        /// <summary>
         /// Sets the USB devices active configuration value. 
         /// </summary>
         /// <param name="config">The active configuration value. A zero value means the device is not configured and a non-zero value indicates the device is configured.</param>

--- a/stage/LibUsbDotNet/IUsbInterface.cs
+++ b/stage/LibUsbDotNet/IUsbInterface.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Info/UsbBaseInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbBaseInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Info/UsbConfigInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbConfigInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Info/UsbDeviceInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbDeviceInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Info/UsbEndpointInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbEndpointInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Info/UsbInterfaceInfo.cs
+++ b/stage/LibUsbDotNet/Info/UsbInterfaceInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/Kernel32.cs
+++ b/stage/LibUsbDotNet/Internal/Kernel32.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/OverlappedTransferContext.cs
+++ b/stage/LibUsbDotNet/Internal/OverlappedTransferContext.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/SafeOverlapped.cs
+++ b/stage/LibUsbDotNet/Internal/SafeOverlapped.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/SetupApi.cs
+++ b/stage/LibUsbDotNet/Internal/SetupApi.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/TransferContextBase.cs
+++ b/stage/LibUsbDotNet/Internal/TransferContextBase.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/UsbApiBase.cs
+++ b/stage/LibUsbDotNet/Internal/UsbApiBase.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/UsbRegex/BaseRegSymbolicName.cs
+++ b/stage/LibUsbDotNet/Internal/UsbRegex/BaseRegSymbolicName.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/UsbRegex/NamedGroup.cs
+++ b/stage/LibUsbDotNet/Internal/UsbRegex/NamedGroup.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/UsbRegex/RegHardwareID.cs
+++ b/stage/LibUsbDotNet/Internal/UsbRegex/RegHardwareID.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Internal/UsbRegex/RegSymbolicName.cs
+++ b/stage/LibUsbDotNet/Internal/UsbRegex/RegSymbolicName.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbAPI.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbAPI.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO_IOControlMessage.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbDriverIO_IOControlMessage.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbIoCtl.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbIoCtl.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/Internal/LibUsbRequest.cs
+++ b/stage/LibUsbDotNet/LibUsb/Internal/LibUsbRequest.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/LibUsbDevice.cs
+++ b/stage/LibUsbDotNet/LibUsb/LibUsbDevice.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/LibUsbDevice.cs
+++ b/stage/LibUsbDotNet/LibUsb/LibUsbDevice.cs
@@ -358,6 +358,16 @@ namespace LibUsbDotNet.LibUsb
 
         internal bool UsbIoSync(int controlCode, Object inBuffer, int inSize, IntPtr outBuffer, int outSize, out int ret) { return LibUsbDriverIO.UsbIOSync(mUsbHandle, controlCode, inBuffer, inSize, outBuffer, outSize, out ret); }
 
+        public bool DetachKernelDriver(int interfaceID)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public bool SetAutoDetachKernelDriver(bool autoDetach)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         /// <summary>
         /// Gets the device filename for this <see cref="LibUsbDevice"/>.
         /// </summary>

--- a/stage/LibUsbDotNet/LibUsb/LibUsbDeviceRegistryKeyRequest.cs
+++ b/stage/LibUsbDotNet/LibUsb/LibUsbDeviceRegistryKeyRequest.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/LibUsbKernelType.cs
+++ b/stage/LibUsbDotNet/LibUsb/LibUsbKernelType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsb/LibUsbRegistry.cs
+++ b/stage/LibUsbDotNet/LibUsb/LibUsbRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <Description>.NET C# USB library for WinUSB, LibUsb-Win32, and libusb-1.0. Using the common device classes, applications work with all operating systems and drivers without modification. Lots of example code. Open source software at sourceforge.net.</Description>
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
-    <VersionPrefix>2.2.9</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
     <DebugType>portable</DebugType>
-    <AssemblyName>LibUsbDotNet.LibUsbDotNet</AssemblyName>
-    <PackageId>LibUsbDotNet</PackageId>
+    <AssemblyName>Verdure.LibUsbDotNet.LibUsbDotNet</AssemblyName>
+    <PackageId>Verdure.LibUsbDotNet</PackageId>
     <PackageProjectUrl>https://github.com/LibUsbDotNet/LibUsbDotNet/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/LibUsbDotNet/LibUsbDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://c.fsdn.com/allura/p/libusbdotnet/icon</PackageIconUrl>
@@ -20,15 +20,19 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>LibUsbDotNet.snk</AssemblyOriginatorKeyFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>LibUsbDotNet modified version</Title>
+    <PackageReleaseNotes>Upgrade the framework to .net6 .net45
+Add the DetachKernelDriver call</PackageReleaseNotes>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
   

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <Description>.NET C# USB library for WinUSB, LibUsb-Win32, and libusb-1.0. Using the common device classes, applications work with all operating systems and drivers without modification. Lots of example code. Open source software at sourceforge.net.</Description>
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.2.9</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
     <TargetFrameworks>netstandard2.0;net46;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
     <DebugType>portable</DebugType>
-    <AssemblyName>Verdure.LibUsbDotNet.LibUsbDotNet</AssemblyName>
-    <PackageId>Verdure.LibUsbDotNet</PackageId>
+    <AssemblyName>LibUsbDotNet.LibUsbDotNet</AssemblyName>
+    <PackageId>LibUsbDotNet</PackageId>
     <PackageProjectUrl>https://github.com/LibUsbDotNet/LibUsbDotNet/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/LibUsbDotNet/LibUsbDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://c.fsdn.com/allura/p/libusbdotnet/icon</PackageIconUrl>
@@ -21,9 +21,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>LibUsbDotNet.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Title>LibUsbDotNet modified version</Title>
-    <PackageReleaseNotes>Upgrade the framework to .net6 .net46
-Add the DetachKernelDriver call</PackageReleaseNotes>
+    <Title></Title>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
     <VersionPrefix>2.2.9</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
-    <TargetFrameworks>netstandard2.0;net45;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>LibUsbDotNet.LibUsbDotNet</AssemblyName>

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -22,7 +22,7 @@
     <AssemblyOriginatorKeyFile>LibUsbDotNet.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>LibUsbDotNet modified version</Title>
-    <PackageReleaseNotes>Upgrade the framework to .net6 .net45
+    <PackageReleaseNotes>Upgrade the framework to .net6 .net46
 Add the DetachKernelDriver call</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/stage/LibUsbDotNet/Main/ControlEpLockType.cs
+++ b/stage/LibUsbDotNet/Main/ControlEpLockType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: sourceforge.net/projects/libusbdotnet/
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/DataEpLockType.cs
+++ b/stage/LibUsbDotNet/Main/DataEpLockType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: sourceforge.net/projects/libusbdotnet/
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/DataReceivedEnabledChangedEventArgs.cs
+++ b/stage/LibUsbDotNet/Main/DataReceivedEnabledChangedEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/DeviceLockType.cs
+++ b/stage/LibUsbDotNet/Main/DeviceLockType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: sourceforge.net/projects/libusbdotnet/
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/DevicePropertyType.cs
+++ b/stage/LibUsbDotNet/Main/DevicePropertyType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/EndpointDataEventArgs.cs
+++ b/stage/LibUsbDotNet/Main/EndpointDataEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/EndpointType.cs
+++ b/stage/LibUsbDotNet/Main/EndpointType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/ErrorCode.cs
+++ b/stage/LibUsbDotNet/Main/ErrorCode.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/Helper.cs
+++ b/stage/LibUsbDotNet/Main/Helper.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/LegacyUsbRegistry.cs
+++ b/stage/LibUsbDotNet/Main/LegacyUsbRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/ReadEndpointID.cs
+++ b/stage/LibUsbDotNet/Main/ReadEndpointID.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/SPDRP.cs
+++ b/stage/LibUsbDotNet/Main/SPDRP.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/SafeContextHandle.cs
+++ b/stage/LibUsbDotNet/Main/SafeContextHandle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/SetupApiRegistry.cs
+++ b/stage/LibUsbDotNet/Main/SetupApiRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbConstants.cs
+++ b/stage/LibUsbDotNet/Main/UsbConstants.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbCtrlFlags.cs
+++ b/stage/LibUsbDotNet/Main/UsbCtrlFlags.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
+++ b/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
+++ b/stage/LibUsbDotNet/Main/UsbEndpointBase.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbEndpointDirection.cs
+++ b/stage/LibUsbDotNet/Main/UsbEndpointDirection.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbEndpointList.cs
+++ b/stage/LibUsbDotNet/Main/UsbEndpointList.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbException.cs
+++ b/stage/LibUsbDotNet/Main/UsbException.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbKernelVersion.cs
+++ b/stage/LibUsbDotNet/Main/UsbKernelVersion.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbLockStyle.cs
+++ b/stage/LibUsbDotNet/Main/UsbLockStyle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: sourceforge.net/projects/libusbdotnet/
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbRegDeviceList.cs
+++ b/stage/LibUsbDotNet/Main/UsbRegDeviceList.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbRegistry.cs
+++ b/stage/LibUsbDotNet/Main/UsbRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbRequestRecipient.cs
+++ b/stage/LibUsbDotNet/Main/UsbRequestRecipient.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbRequestType.cs
+++ b/stage/LibUsbDotNet/Main/UsbRequestType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbSetupPacket.cs
+++ b/stage/LibUsbDotNet/Main/UsbSetupPacket.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+ï»¿// Copyright Â© 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -25,7 +25,7 @@ namespace LibUsbDotNet.Main
 {
     /// <summary> Transfers data to the main control endpoint (Endpoint 0).
     /// </summary> 
-    /// <remarks> All USB devices respond to requests from the host on the device’s Default Control Pipe. These requests are made using control transfers. The request and the request’s parameters are sent to the device in the Setup packet. The host is responsible for establishing the values passed in the fields. Every Setup packet has eight bytes.
+    /// <remarks> All USB devices respond to requests from the host on the deviceâ€™s Default Control Pipe. These requests are made using control transfers. The request and the requestâ€™s parameters are sent to the device in the Setup packet. The host is responsible for establishing the values passed in the fields. Every Setup packet has eight bytes.
     /// </remarks> 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct UsbSetupPacket

--- a/stage/LibUsbDotNet/Main/UsbStandardRequest.cs
+++ b/stage/LibUsbDotNet/Main/UsbStandardRequest.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+ï»¿// Copyright Â© 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -71,7 +71,7 @@ namespace LibUsbDotNet.Main
         /// </summary>
         SetInterface = 0x0B,
         /// <summary>
-        /// Used to set and then report an endpoint’s synchronization frame.
+        /// Used to set and then report an endpointâ€™s synchronization frame.
         /// </summary>
         SynchFrame = 0x0C,
     }

--- a/stage/LibUsbDotNet/Main/UsbStatusClodes.cs
+++ b/stage/LibUsbDotNet/Main/UsbStatusClodes.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbStream.cs
+++ b/stage/LibUsbDotNet/Main/UsbStream.cs
@@ -1,4 +1,4 @@
-﻿ļ»æ// Copyright Ā© 2006-2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbStream.cs
+++ b/stage/LibUsbDotNet/Main/UsbStream.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2006-2009 Travis Robinson. All rights reserved.
+﻿ļ»æ// Copyright Ā© 2006-2009 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbSymbolicName.cs
+++ b/stage/LibUsbDotNet/Main/UsbSymbolicName.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/UsbTransfer.cs
+++ b/stage/LibUsbDotNet/Main/UsbTransfer.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/Main/WriteEndpointID.cs
+++ b/stage/LibUsbDotNet/Main/WriteEndpointID.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/CallbackDelegates.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/CallbackDelegates.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using MonoLibUsb.Transfer;
 

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson <libusbdotnet@gmail.com>
+﻿// Copyright © 2006-2010 Travis Robinson <libusbdotnet@gmail.com>
 // Copyright © 2017 Andras Fuchs <andras.fuchs@gmail.com>
 // 
 // Website: http://sourceforge.net/projects/libusbdotnet

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -467,7 +467,15 @@ namespace MonoLibUsb
         /// </returns>
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_detach_kernel_driver")]
         public static extern int DetachKernelDriver([In] MonoUsbDeviceHandle deviceHandle, int interfaceNumber);
+        /// <summary>
+        /// Automatic kernel driver detachment is disabled on newly opened device handles by default.
+        /// </summary>
+        /// <param name="deviceHandle"></param>
+        /// <param name="enable">Enable/disable libusb's automatic kernel driver detachment.</param>
+        /// <returns></returns>
 
+        [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_set_auto_detach_kernel_driver")]
+        public static extern int SetAutoDetachKernelDriver([In] MonoUsbDeviceHandle deviceHandle, int enable);
         /// <summary>
         /// Re-attach an interface's kernel driver, which was previously detached using <see cref="DetachKernelDriver"/>.
         /// </summary>

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApi.cs
@@ -468,10 +468,13 @@ namespace MonoLibUsb
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_detach_kernel_driver")]
         public static extern int DetachKernelDriver([In] MonoUsbDeviceHandle deviceHandle, int interfaceNumber);
         /// <summary>
-        /// Automatic kernel driver detachment is disabled on newly opened device handles by default.
+        /// When this is enabled libusb will automatically detach the kernel driver on an interface when claiming the interface, and attach it when releasing the interface.
         /// </summary>
-        /// <param name="deviceHandle"></param>
-        /// <param name="enable">Enable/disable libusb's automatic kernel driver detachment.</param>
+        /// <remarks>
+        /// <note type="tip" title="Libusb-1.0 API:"><seelibusb10 group="dev"/></note>
+        /// </remarks>
+        /// <param name="deviceHandle">A device handle.</param>
+        /// <param name="enable"> If the enable argument is non-zero the feature is enabled. Else disabled. Returns 0 on success and a LIBUSB_ERROR code on failure.</param>
         /// <returns></returns>
 
         [DllImport(LIBUSB_DLL, CallingConvention = CC, SetLastError = false, EntryPoint = "libusb_set_auto_detach_kernel_driver")]

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
@@ -19,17 +19,17 @@
 // visit www.gnu.org.
 // 
 // 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using LibUsbDotNet.Descriptors;
 using LibUsbDotNet.Info;
 using LibUsbDotNet.Main;
 using MonoLibUsb;
 using MonoLibUsb.Descriptors;
 using MonoLibUsb.Profile;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace LibUsbDotNet.LudnMonoLibUsb
 {
@@ -89,7 +89,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
                     {
                         mMonoUSBProfileList = new MonoUsbProfileList();
                     }
-                    int ret = (int) mMonoUSBProfileList.Refresh(MonoUsbEventHandler.SessionHandle);
+                    int ret = (int)mMonoUSBProfileList.Refresh(MonoUsbEventHandler.SessionHandle);
                     if (ret < 0) return null;
                     List<MonoUsbDevice> rtnList = new List<MonoUsbDevice>();
                     for (int iProfile = 0; iProfile < mMonoUSBProfileList.Count; iProfile++)
@@ -137,7 +137,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             if (!IsOpen) throw new UsbException(this, "Device is not opened.");
             ActiveEndpoints.Clear();
 
-            if ((ret = MonoUsbApi.ResetDevice((MonoUsbDeviceHandle) mUsbHandle)) != 0)
+            if ((ret = MonoUsbApi.ResetDevice((MonoUsbDeviceHandle)mUsbHandle)) != 0)
             {
                 UsbError.Error(ErrorCode.MonoApiError, ret, "ResetDevice Failed", this);
             }
@@ -188,16 +188,16 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override bool ControlTransfer(ref UsbSetupPacket setupPacket, IntPtr buffer, int bufferLength, out int lengthTransferred)
         {
             Debug.WriteLine(GetType().Name + ".ControlTransfer() Before", "Libusb-1.0");
-            int ret = MonoUsbApi.ControlTransferAsync((MonoUsbDeviceHandle) mUsbHandle,
+            int ret = MonoUsbApi.ControlTransferAsync((MonoUsbDeviceHandle)mUsbHandle,
                                                       setupPacket.RequestType,
                                                       setupPacket.Request,
                                                       setupPacket.Value,
                                                       setupPacket.Index,
                                                       buffer,
-                                                      (short) bufferLength,
+                                                      (short)bufferLength,
                                                       UsbConstants.DEFAULT_TIMEOUT);
 
-            Debug.WriteLine(GetType().Name + ".ControlTransfer() Error:" + ((MonoUsbError) ret).ToString(), "Libusb-1.0");
+            Debug.WriteLine(GetType().Name + ".ControlTransfer() Error:" + ((MonoUsbError)ret).ToString(), "Libusb-1.0");
             if (ret < 0)
             {
                 UsbError.Error(ErrorCode.MonoApiError, ret, "ControlTransfer Failed", this);
@@ -226,7 +226,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             if (!wasOpen) Open();
             if (!IsOpen) return false;
 
-            int ret = MonoUsbApi.GetDescriptor((MonoUsbDeviceHandle) mUsbHandle, descriptorType, index, buffer, (ushort) bufferLength);
+            int ret = MonoUsbApi.GetDescriptor((MonoUsbDeviceHandle)mUsbHandle, descriptorType, index, buffer, (ushort)bufferLength);
 
             if (ret < 0)
             {
@@ -256,7 +256,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             MonoUsbDeviceHandle handle = new MonoUsbDeviceHandle(mMonoUSBProfile.ProfileHandle);
             if (handle.IsInvalid)
             {
-                UsbError.Error(ErrorCode.MonoApiError, (int) MonoUsbDeviceHandle.LastErrorCode, "MonoUsbDevice.Open Failed", this);
+                UsbError.Error(ErrorCode.MonoApiError, (int)MonoUsbDeviceHandle.LastErrorCode, "MonoUsbDevice.Open Failed", this);
                 mUsbHandle = null;
                 return false;
             }
@@ -287,13 +287,13 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         public override UsbEndpointReader OpenEndpointReader(ReadEndpointID readEndpointID, int readBufferSize, EndpointType endpointType)
         {
             foreach (UsbEndpointBase activeEndpoint in mActiveEndpoints)
-                if (activeEndpoint.EpNum == (byte)readEndpointID) 
+                if (activeEndpoint.EpNum == (byte)readEndpointID)
                     return (UsbEndpointReader)activeEndpoint;
 
             byte altIntefaceID = mClaimedInterfaces.Count == 0 ? UsbAltInterfaceSettings[0] : UsbAltInterfaceSettings[mClaimedInterfaces[mClaimedInterfaces.Count - 1]];
 
             UsbEndpointReader epNew = new MonoUsbEndpointReader(this, readBufferSize, altIntefaceID, readEndpointID, endpointType);
-            return (UsbEndpointReader) ActiveEndpoints.Add(epNew);
+            return (UsbEndpointReader)ActiveEndpoints.Add(epNew);
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             byte altIntefaceID = mClaimedInterfaces.Count == 0 ? UsbAltInterfaceSettings[0] : UsbAltInterfaceSettings[mClaimedInterfaces[mClaimedInterfaces.Count - 1]];
 
             UsbEndpointWriter epNew = new MonoUsbEndpointWriter(this, altIntefaceID, writeEndpointID, endpointType);
-            return (UsbEndpointWriter) mActiveEndpoints.Add(epNew);
+            return (UsbEndpointWriter)mActiveEndpoints.Add(epNew);
         }
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// </remarks>
         public bool SetConfiguration(byte config)
         {
-            int ret = MonoUsbApi.SetConfiguration((MonoUsbDeviceHandle) mUsbHandle, config);
+            int ret = MonoUsbApi.SetConfiguration((MonoUsbDeviceHandle)mUsbHandle, config);
             if (ret != 0)
             {
                 UsbError.Error(ErrorCode.MonoApiError, ret, "SetConfiguration Failed", this);
@@ -343,13 +343,13 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         {
             config = 0;
             int iconfig = 0;
-            int ret = MonoUsbApi.GetConfiguration((MonoUsbDeviceHandle) mUsbHandle, ref iconfig);
+            int ret = MonoUsbApi.GetConfiguration((MonoUsbDeviceHandle)mUsbHandle, ref iconfig);
             if (ret != 0)
             {
                 UsbError.Error(ErrorCode.MonoApiError, ret, "GetConfiguration Failed", this);
                 return false;
             }
-            config = (byte) iconfig;
+            config = (byte)iconfig;
             mCurrentConfigValue = config;
 
             return true;
@@ -445,7 +445,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// <returns>True on success.</returns>
         public bool ReleaseInterface(int interfaceID)
         {
-            int ret = MonoUsbApi.ReleaseInterface((MonoUsbDeviceHandle) mUsbHandle, interfaceID);
+            int ret = MonoUsbApi.ReleaseInterface((MonoUsbDeviceHandle)mUsbHandle, interfaceID);
             if (!mClaimedInterfaces.Remove(interfaceID)) return true;
 
             if (ret != 0)
@@ -463,13 +463,13 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// <returns>True on success.</returns>
         public bool SetAltInterface(int interfaceID, int alternateID)
         {
-            int ret = MonoUsbApi.SetInterfaceAltSetting((MonoUsbDeviceHandle) mUsbHandle, interfaceID, alternateID);
+            int ret = MonoUsbApi.SetInterfaceAltSetting((MonoUsbDeviceHandle)mUsbHandle, interfaceID, alternateID);
             if (ret != 0)
             {
                 UsbError.Error(ErrorCode.MonoApiError, ret, "SetAltInterface Failed", this);
                 return false;
             }
-            UsbAltInterfaceSettings[interfaceID & (UsbConstants.MAX_DEVICES-1)] = (byte)alternateID;
+            UsbAltInterfaceSettings[interfaceID & (UsbConstants.MAX_DEVICES - 1)] = (byte)alternateID;
             return true;
         }
 
@@ -500,7 +500,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             for (int iConfig = 0; iConfig < iConfigs; iConfig++)
             {
                 MonoUsbConfigHandle nextConfigHandle;
-                int ret = MonoUsbApi.GetConfigDescriptor(usbDevice.mMonoUSBProfile.ProfileHandle, (byte) iConfig, out nextConfigHandle);
+                int ret = MonoUsbApi.GetConfigDescriptor(usbDevice.mMonoUSBProfile.ProfileHandle, (byte)iConfig, out nextConfigHandle);
                 Debug.WriteLine(string.Format("GetConfigDescriptor:{0}", ret));
                 if (ret != 0 || nextConfigHandle.IsInvalid)
                 {
@@ -541,7 +541,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
                 {
                     mMonoUSBProfileList = new MonoUsbProfileList();
                 }
-                return (int) mMonoUSBProfileList.Refresh(MonoUsbEventHandler.SessionHandle);
+                return (int)mMonoUSBProfileList.Refresh(MonoUsbEventHandler.SessionHandle);
             }
         }
 
@@ -553,6 +553,28 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         /// <para>Usually there is no need to call this functions externally.</para> 
         /// </remarks>
         public static void Init() { MonoUsbApi.InitAndStart(); }
+
+        public bool DetachKernelDriver(int interfaceID)
+        {
+            int ret = MonoUsbApi.DetachKernelDriver((MonoUsbDeviceHandle)mUsbHandle, interfaceID);
+            if (ret != 0)
+            {
+                UsbError.Error(ErrorCode.MonoApiError, ret, "Detach Kernel Driver Failed", this);
+                return false;
+            }
+            return true;
+        }
+
+        public bool SetAutoDetachKernelDriver(bool autoDetach)
+        {
+            int ret = MonoUsbApi.SetAutoDetachKernelDriver((MonoUsbDeviceHandle)mUsbHandle, autoDetach ? 1 : 0);
+            if (ret != 0)
+            {
+                UsbError.Error(ErrorCode.MonoApiError, ret, "Set Auto DetachKernel Driver Failed", this);
+                return false;
+            }
+            return true;
+        }
 
         /// <summary>
         /// Gets the "device path" for this device (constructed)

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
@@ -570,7 +570,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             int ret = MonoUsbApi.SetAutoDetachKernelDriver((MonoUsbDeviceHandle)mUsbHandle, autoDetach ? 1 : 0);
             if (ret != 0)
             {
-                UsbError.Error(ErrorCode.MonoApiError, ret, "Set Auto DetachKernel Driver Failed", this);
+                UsbError.Error(ErrorCode.MonoApiError, ret, "Set Auto Detach Kernel Driver Failed", this);
                 return false;
             }
             return true;

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDeviceHandle.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDeviceHandle.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointReader.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointReader.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointWriter.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEndpointWriter.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbError.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbError.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEventHandler.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbSessionHandle.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbSessionHandle.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using LibUsbDotNet.Main;

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/AddRemoveEventArgs.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/AddRemoveEventArgs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace MonoLibUsb.Profile
 {

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/AddRemoveType.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/AddRemoveType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfile.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfile.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileHandle.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileHandle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileHandleEnumerator.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileHandleEnumerator.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileList.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileList.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileListHandle.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Profile/MonoUsbProfileListHandle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_control_setup.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_control_setup.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using LibUsbDotNet.Main;
 
 namespace MonoLibUsb.Transfer.Internal

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_iso_packet_descriptor.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_iso_packet_descriptor.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace MonoLibUsb.Transfer.Internal
 {

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_transfer.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/Internal/libusb_transfer.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbControlSetup.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbControlSetup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using LibUsbDotNet.Main;
 using MonoLibUsb.Transfer.Internal;

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbIsoPacket.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbIsoPacket.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using MonoLibUsb.Transfer.Internal;
 

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTansferStatus.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTansferStatus.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransfer.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransfer.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferFlags.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/Transfer/MonoUsbTransferFlags.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/MonoLibUsb/UnixNativeTimeval.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/UnixNativeTimeval.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using LibUsbDotNet.Main;
 

--- a/stage/LibUsbDotNet/UsbDevice.cs
+++ b/stage/LibUsbDotNet/UsbDevice.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/UsbEndpointReader.cs
+++ b/stage/LibUsbDotNet/UsbEndpointReader.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/UsbEndpointWriter.cs
+++ b/stage/LibUsbDotNet/UsbEndpointWriter.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/UsbGlobals.cs
+++ b/stage/LibUsbDotNet/UsbGlobals.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/DeviceInformationTypes.cs
+++ b/stage/LibUsbDotNet/WinUsb/DeviceInformationTypes.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/DeviceSpeedTypes.cs
+++ b/stage/LibUsbDotNet/WinUsb/DeviceSpeedTypes.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/Internal/SafeWinUsbInterfaceHandle.cs
+++ b/stage/LibUsbDotNet/WinUsb/Internal/SafeWinUsbInterfaceHandle.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
+++ b/stage/LibUsbDotNet/WinUsb/Internal/WinUsbAPI.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/PipeInformation.cs
+++ b/stage/LibUsbDotNet/WinUsb/PipeInformation.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/PipePolicies.cs
+++ b/stage/LibUsbDotNet/WinUsb/PipePolicies.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/PipePolicyType.cs
+++ b/stage/LibUsbDotNet/WinUsb/PipePolicyType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/PowerPolicies.cs
+++ b/stage/LibUsbDotNet/WinUsb/PowerPolicies.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/PowerPolicyType.cs
+++ b/stage/LibUsbDotNet/WinUsb/PowerPolicyType.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/WinUsbDevice.cs
+++ b/stage/LibUsbDotNet/WinUsb/WinUsbDevice.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/LibUsbDotNet/WinUsb/WinUsbRegistry.cs
+++ b/stage/LibUsbDotNet/WinUsb/WinUsbRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/Test_Bulk/Program.cs
+++ b/stage/Test_Bulk/Program.cs
@@ -1,4 +1,4 @@
-// Copyright � 2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2009 Travis Robinson. All rights reserved.
 // 
 // website: sourceforge.net/projects/libusbdotnet/
 // e-mail:  trobinso@users.sourceforge.net

--- a/stage/Test_Bulk/Test_Bulk.csproj
+++ b/stage/Test_Bulk/Test_Bulk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/stage/Test_Bulk/fTestBulk.Designer.cs
+++ b/stage/Test_Bulk/fTestBulk.Designer.cs
@@ -1,4 +1,4 @@
-namespace Test_Bulk
+﻿namespace Test_Bulk
 {
     partial class fTestBulk
     {

--- a/stage/Test_Bulk/fTestBulk.cs
+++ b/stage/Test_Bulk/fTestBulk.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/Test_DeviceNotify/Program.cs
+++ b/stage/Test_DeviceNotify/Program.cs
@@ -1,4 +1,4 @@
-// Copyright � 2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2009 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  trobinso@users.sourceforge.net

--- a/stage/Test_DeviceNotify/Test_DeviceNotify.csproj
+++ b/stage/Test_DeviceNotify/Test_DeviceNotify.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/stage/Test_DeviceNotify/fTestDeviceNotify.Designer.cs
+++ b/stage/Test_DeviceNotify/fTestDeviceNotify.Designer.cs
@@ -1,4 +1,4 @@
-namespace Test_DeviceNotify
+﻿namespace Test_DeviceNotify
 {
     partial class fTestDeviceNotify
     {

--- a/stage/Test_DeviceNotify/fTestDeviceNotify.cs
+++ b/stage/Test_DeviceNotify/fTestDeviceNotify.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Windows.Forms;
 using LibUsbDotNet.DeviceNotify;

--- a/stage/Test_Info/Program.cs
+++ b/stage/Test_Info/Program.cs
@@ -1,4 +1,4 @@
-// Copyright � 2009 Travis Robinson. All rights reserved.
+﻿// Copyright © 2009 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  trobinso@users.sourceforge.net

--- a/stage/Test_Info/Test_Info.csproj
+++ b/stage/Test_Info/Test_Info.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/stage/Test_Info/fTestInfo.Designer.cs
+++ b/stage/Test_Info/fTestInfo.Designer.cs
@@ -1,4 +1,4 @@
-namespace Test_Info
+﻿namespace Test_Info
 {
     partial class fTestInfo
     {

--- a/stage/Test_Info/fTestInfo.cs
+++ b/stage/Test_Info/fTestInfo.cs
@@ -1,4 +1,4 @@
-// Copyright � 2006-2010 Travis Robinson. All rights reserved.
+﻿// Copyright © 2006-2010 Travis Robinson. All rights reserved.
 // 
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com

--- a/stage/version.json
+++ b/stage/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.2",
+  "version": "2.3",
   "buildNumberOffset": "20", 
   "publicReleaseRefSpec": [
     "^refs/heads/master$",

--- a/stage/version.json
+++ b/stage/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.3",
+  "version": "2.2",
   "buildNumberOffset": "20", 
   "publicReleaseRefSpec": [
     "^refs/heads/master$",


### PR DESCRIPTION
The project framework was upgraded to .NET 6 to add method calls for DetachKernelDriver and SetAutoDetachKernelDriver.

Since I am in China, the default code of the project will report an error when opening on my side, I changed the default coding of some code related to the library to the version of UTF-8 BOM, I hope you can test it on your side.