### PR TITLE
Native libusb version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+# JetBrains Rider options directory
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/src/LibUsbDotNet/LibUsb/NativeLibraryVersion.cs
+++ b/src/LibUsbDotNet/LibUsb/NativeLibraryVersion.cs
@@ -1,0 +1,45 @@
+namespace LibUsbDotNet.LibUsb;
+
+public static class NativeLibraryVersion
+{
+    static unsafe NativeLibraryVersion()
+    {
+        var version = NativeMethods.GetVersion();
+        Major = version->Major;
+        Minor = version->Minor;
+        Micro = version->Micro;
+        Nano = version->Nano;
+    }
+    
+    /// <summary>
+    ///  Library major version.
+    /// </summary>
+    public static ushort Major { get; }
+
+    /// <summary>
+    ///  Library minor version.
+    /// </summary>
+    public static ushort Minor { get; }
+
+    /// <summary>
+    ///  Library micro version.
+    /// </summary>
+    public static ushort Micro { get; }
+
+    /// <summary>
+    ///  Library nano version.
+    /// </summary>
+    public static ushort Nano { get; }
+
+    /// <summary>
+    /// libusb version with nano included
+    /// </summary>
+    public static string FullVersion 
+        => $"{Major}.{Minor}.{Micro}.{Nano}";
+    
+    /// <summary>
+    /// libusb version
+    /// </summary>
+    public static string Version 
+        => $"{Major}.{Minor}.{Micro}";
+}


### PR DESCRIPTION
Add static class to get the native libusb version. This is useful for ensuring the libusb version LibUsbDotNet resolved is the expected version. When I built libusb 1.0.26 on both Fedora and Ubuntu using the default ./configure options, LibUsbDotNet resolved the 1.0.25 version that came pre-installed with OS.

Also added JetBrains Rider options directory to gitignore, it's such a minor change I don't think it needs its own PR.