### PR TITLE
Add langId parameter to MonoUsbApi.GetDescriptor

### DIFF
--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
@@ -77,6 +77,7 @@ namespace MonoLibUsb
         /// <param name="deviceHandle">Retrieve a descriptor from the default control pipe.</param>
         /// <param name="descType">The descriptor type, <see cref="DescriptorType"/></param>
         /// <param name="descIndex">The index of the descriptor to retrieve.</param>
+        /// <param name="langId">Descriptor language id.</param>
         /// <param name="pData">Output buffer for descriptor.</param>
         /// <param name="length">Size of data buffer.</param>
         /// <returns>Number of bytes returned in data, or a <see cref="MonoUsbError"/> code on failure.</returns>

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoLibUsbApiHelpers.cs
@@ -80,13 +80,13 @@ namespace MonoLibUsb
         /// <param name="pData">Output buffer for descriptor.</param>
         /// <param name="length">Size of data buffer.</param>
         /// <returns>Number of bytes returned in data, or a <see cref="MonoUsbError"/> code on failure.</returns>
-        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, IntPtr pData, int length)
+        public static int GetDescriptor(MonoUsbDeviceHandle deviceHandle, byte descType, byte descIndex, short langId, IntPtr pData, int length)
         {
             return ControlTransfer(deviceHandle,
                                            (byte)UsbEndpointDirection.EndpointIn,
                                            (byte)UsbStandardRequest.GetDescriptor,
                                            (short)((descType << 8) | descIndex),
-                                           0,
+                                           langId,
                                            pData,
                                            (short)length,
                                            1000);

--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
@@ -226,7 +226,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
             if (!wasOpen) Open();
             if (!IsOpen) return false;
 
-            int ret = MonoUsbApi.GetDescriptor((MonoUsbDeviceHandle)mUsbHandle, descriptorType, index, buffer, (ushort)bufferLength);
+            int ret = MonoUsbApi.GetDescriptor((MonoUsbDeviceHandle)mUsbHandle, descriptorType, index, langId, buffer, (ushort)bufferLength);
 
             if (ret < 0)
             {


### PR DESCRIPTION
MonoUsbDevice.GetDescriptor should pass the langId parameter to MonoUsbApi.GetDescriptor in order to have the correct parameters for the Control Transfer.

Otherwise, the Control Transfer fails with LIBUSB_ERROR_PIPE  (control request not supported) for all Descriptors EXCEPT Device Descriptor, Configuration Descriptor and String Descriptor index 0.

This pull request fixes null string descriptors in the UsbDevice.Info when LibUsbDotNet  is used under Linux or under Windows with libusb-1.0 backend (ForceLibUsbWinBack set true) ... This was my use case; Tested under Windows with libusb-1.0.26 and under Linux (on a raspberry Pi4)

This pull request probably also fixes #164
Probably also related to #122 #146 #188