### PR TITLE
Update target frameworks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - name: Build
         run: dotnet pack src\LibUsbDotNet\LibUsbDotNet.csproj -c Release -o ${{ github.workspace }}/nuget/
@@ -134,7 +134,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - name: Test
         run: |
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - name: Install libusb
         run: |

--- a/src/BenchmarkCon/BenchmarkCon.csproj
+++ b/src/BenchmarkCon/BenchmarkCon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Read.Isochronous/Read.Isochronous.csproj
+++ b/src/Examples/Read.Isochronous/Read.Isochronous.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Read.Only/Read.Only.csproj
+++ b/src/Examples/Read.Only/Read.Only.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Read.Write.Async/Read.Write.Async.csproj
+++ b/src/Examples/Read.Write.Async/Read.Write.Async.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Read.Write/Read.Write.csproj
+++ b/src/Examples/Read.Write/Read.Write.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Show.Info/Show.Info.csproj
+++ b/src/Examples/Show.Info/Show.Info.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
+++ b/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>

--- a/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
+++ b/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>

--- a/src/LibUsbDotNet/Generated/Context.cs
+++ b/src/LibUsbDotNet/Generated/Context.cs
@@ -38,8 +38,6 @@ namespace LibUsbDotNet
     /// <summary>
     /// Represents a wrapper class for <c>libusb_context</c> handles.
     /// </summary>
-    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
     public partial class Context : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;

--- a/src/LibUsbDotNet/Generated/Device.cs
+++ b/src/LibUsbDotNet/Generated/Device.cs
@@ -38,8 +38,6 @@ namespace LibUsbDotNet
     /// <summary>
     /// Represents a wrapper class for <c>libusb_device</c> handles.
     /// </summary>
-    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
     public partial class Device : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;

--- a/src/LibUsbDotNet/Generated/DeviceHandle.cs
+++ b/src/LibUsbDotNet/Generated/DeviceHandle.cs
@@ -38,8 +38,6 @@ namespace LibUsbDotNet
     /// <summary>
     /// Represents a wrapper class for <c>libusb_device_handle</c> handles.
     /// </summary>
-    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
     public partial class DeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string creationStackTrace;

--- a/src/LibUsbDotNet/Info/UsbBaseInfo.cs
+++ b/src/LibUsbDotNet/Info/UsbBaseInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright Â© 2006-2010 Travis Robinson. All rights reserved.
 //
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -33,7 +33,7 @@ namespace LibUsbDotNet.Info
     public abstract class UsbBaseInfo
     {
         protected byte[] RawDescriptors { get; set; }
-#if NET45
+#if NETSTANDARD2_0
             = new byte[] { };
 #else
             = Array.Empty<byte>();

--- a/src/LibUsbDotNet/LibUsb/NativeLibraryResolver.cs
+++ b/src/LibUsbDotNet/LibUsb/NativeLibraryResolver.cs
@@ -12,7 +12,7 @@ namespace LibUsbDotNet.LibUsb
     {
         static NativeLibraryResolver()
         {
-#if !NET45
+#if !NETSTANDARD2_0
             NativeLibrary.SetDllImportResolver(typeof(NativeLibraryResolver).Assembly, DllImportResolver);
 #endif
         }
@@ -25,7 +25,7 @@ namespace LibUsbDotNet.LibUsb
             // Dummy method to trigger the static constructor.
         }
 
-#if !NET45
+#if !NETSTANDARD2_0
         private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
             if (libraryName != NativeMethods.LibUsbNativeLibrary)

--- a/src/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/src/LibUsbDotNet/LibUsbDotNet.csproj
@@ -5,8 +5,7 @@
     <AssemblyTitle>LibUsbDotNet</AssemblyTitle>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/LibUsbDotNet/LibUsbDotNet/</PackageProjectUrl>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <PackageIconUrl>http://c.fsdn.com/allura/p/libusbdotnet/icon</PackageIconUrl>
@@ -19,10 +18,8 @@
     <AssemblyOriginatorKeyFile>LibUsbDotNet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since PR #193 will need a minimum of .NET Framework 4.6 anyway, I think it makes sense to update the target frameworks to .NET Standard 2.0 + .NET 6 + .NET 7.

Also removed the SecurityPermission attributes, since they are [deprecated](https://learn.microsoft.com/en-us/dotnet/api/system.security.permissions.securitypermission?view=windowsdesktop-8.0).