### PR TITLE
Allow LibUsbDotnet.Generator to build.

### DIFF
--- a/src/LibUsbDotNet.Generator/EnumVisitor.cs
+++ b/src/LibUsbDotNet.Generator/EnumVisitor.cs
@@ -2,10 +2,10 @@
 // Copyright (c) Quamotion. All rights reserved.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Text;
 using Core.Clang;
+using Core.Clang.Documentation.Doxygen;
 using Enum = LibUsbDotNet.Generator.Primitives.Enum;
 using EnumValue = LibUsbDotNet.Generator.Primitives.EnumValue;
 
@@ -132,8 +132,8 @@ namespace LibUsbDotNet.Generator
             // - Full Comment
             // - Paragraph Comment
             // - Text Comment
-            var fullComment = cursor.GetParsedComment();
-            var fullCommentKind = fullComment.Kind;
+            var fullComment = Comment.FromCursor(cursor);
+            var fullCommentKind = fullComment.GetKind();
             var fullCommentChildren = fullComment.GetNumChildren();
 
             if (fullCommentKind != CommentKind.FullComment || fullCommentChildren < 1)
@@ -144,10 +144,10 @@ namespace LibUsbDotNet.Generator
             StringBuilder text = new StringBuilder();
             bool hasComment = false;
 
-            for (int i = 0; i < fullCommentChildren; i++)
+            for (uint i = 0; i < fullCommentChildren; i++)
             {
                 var paragraphComment = fullComment.GetChild(i);
-                var paragraphCommentKind = paragraphComment.Kind;
+                var paragraphCommentKind = paragraphComment.GetKind();
                 var paragraphCommentChildren = paragraphComment.GetNumChildren();
 
                 if (paragraphCommentKind != CommentKind.Paragraph || paragraphCommentChildren != 1)
@@ -156,11 +156,11 @@ namespace LibUsbDotNet.Generator
                 }
 
                 var textComment = paragraphComment.GetChild(0);
-                var textCommentKind = textComment.Kind;
+                var textCommentKind = textComment.GetKind();
 
                 if (textCommentKind == CommentKind.Text)
                 {
-                    var commentText = textComment.GetText();
+                    var commentText = textComment.GetNormalizedText();
 
                     if (!string.IsNullOrWhiteSpace(commentText))
                     {

--- a/src/LibUsbDotNet.Generator/Generator.cs
+++ b/src/LibUsbDotNet.Generator/Generator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Delegate = LibUsbDotNet.Generator.Primitives.Delegate;
 using Enum = LibUsbDotNet.Generator.Primitives.Enum;
 using CSharpSyntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree;
+using Index = Core.Clang.Index;
 using SyntaxNodeExtensions = Microsoft.CodeAnalysis.SyntaxNodeExtensions;
 
 namespace LibUsbDotNet.Generator

--- a/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
+++ b/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Core.Clang" Version="5.1.5-beta" />
+    <PackageReference Include="Core.Clang" Version="6.0.0-alpha1" />
     <PackageReference Include="Native.LibClang.win-x64" Version="5.0.0-alpha1" />
     <PackageReference Include="Nustache" Version="1.16.0.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp " Version="2.9.0" />

--- a/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
+++ b/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
@@ -2,7 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibUsbDotNet.Generator/NameConversions.cs
+++ b/src/LibUsbDotNet.Generator/NameConversions.cs
@@ -43,7 +43,7 @@ namespace LibUsbDotNet.Generator
                 patchedName = patchedName.Substring(prefix.Length);
             }
 
-            List<string> parts = new List<string>(patchedName.Split('_', StringSplitOptions.RemoveEmptyEntries));
+            List<string> parts = new List<string>(patchedName.Split(new char[] { '_' }, StringSplitOptions.RemoveEmptyEntries));
 
             StringBuilder nameBuilder = new StringBuilder();
 

--- a/src/LibUsbDotNet.Generator/StructVisitor.cs
+++ b/src/LibUsbDotNet.Generator/StructVisitor.cs
@@ -6,8 +6,8 @@ using Core.Clang;
 using LibUsbDotNet.Generator.Primitives;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
+using Core.Clang.Documentation.Doxygen;
 
 namespace LibUsbDotNet.Generator
 {
@@ -226,8 +226,8 @@ namespace LibUsbDotNet.Generator
             // - Full Comment
             // - Paragraph Comment or ParamCommand comment
             // - Text Comment
-            var fullComment = cursor.GetParsedComment();
-            var fullCommentKind = fullComment.Kind;
+            var fullComment = Comment.FromCursor(cursor);
+            var fullCommentKind = fullComment.GetKind();
             var fullCommentChildren = fullComment.GetNumChildren();
 
             if (fullCommentKind != CommentKind.FullComment || fullCommentChildren < 1)
@@ -237,10 +237,10 @@ namespace LibUsbDotNet.Generator
 
             StringBuilder comment = new StringBuilder();
 
-            for (int i = 0; i < fullCommentChildren; i++)
+            for (uint i = 0; i < fullCommentChildren; i++)
             {
                 var childComment = fullComment.GetChild(i);
-                var childCommentKind = childComment.Kind;
+                var childCommentKind = childComment.GetKind();
 
                 if (childCommentKind != CommentKind.Paragraph
                     && childCommentKind != CommentKind.ParamCommand
@@ -262,9 +262,9 @@ namespace LibUsbDotNet.Generator
                 {
                     comment.Append(text);
                 }
-                else if (childCommentKind == CommentKind.BlockCommand)
+                else if (childCommentKind == CommentKind.BlockCommand && childComment is BlockCommandComment blockCommandComment)
                 {
-                    var name = childComment.GetCommandName();
+                    var name = blockCommandComment.GetCommandName();
                     throw new NotImplementedException();
                 }
             }
@@ -274,11 +274,11 @@ namespace LibUsbDotNet.Generator
 
         private static void GetCommentInnerText(Comment comment, StringBuilder builder)
         {
-            var commentKind = comment.Kind;
+            var commentKind = comment.GetKind();
 
             if (commentKind == CommentKind.Text)
             {
-                var text = comment.GetText();
+                var text = comment.GetNormalizedText();
                 text = text.Trim();
 
                 if (!string.IsNullOrWhiteSpace(text))
@@ -292,7 +292,7 @@ namespace LibUsbDotNet.Generator
                 // Recurse
                 var childCount = comment.GetNumChildren();
 
-                for (int i = 0; i < childCount; i++)
+                for (uint i = 0; i < childCount; i++)
                 {
                     var child = comment.GetChild(i);
                     GetCommentInnerText(child, builder);


### PR DESCRIPTION
To fix issue #201. The errors were mostly caused by out of date calls to the Core.Clang library. I tried to replace them with closest equivalents I could find.

Also, I changed the target framework to .NET Framework 4.7, since it seems Nustache only supports Framework. Other changes to the .csproj were to fix various warnings I got when building.

The project can build now, but I'm not sure if it will actually be useful at generating bindings. However, I'm not sure how much that matters, will it ever be necessary to re-generate bindings for libusb?