### PR TITLE
Show info example fix

### DIFF
--- a/src/Examples/Show.Info/ShowInfo.cs
+++ b/src/Examples/Show.Info/ShowInfo.cs
@@ -13,33 +13,35 @@ namespace Examples
             using (UsbContext context = new UsbContext())
             {
                 var allDevices = context.List();
-                foreach (var usbRegistry in allDevices)
+                foreach (UsbDevice device in allDevices)
                 {
-                    Console.WriteLine(usbRegistry.Info.ToString());
+                    bool openedDevice = device.TryOpen();
 
-                    if (usbRegistry.TryOpen())
+                    Console.WriteLine(device.Info.ToString());
+                    
+                    if (!openedDevice)
+                        continue;
+                    
+                    foreach (var configInfo in device.Configs)
                     {
-                        for (int iConfig = 0; iConfig < usbRegistry.Configs.Count; iConfig++)
+                        Console.WriteLine($"\t{configInfo.ToString().ReplaceLineEndings("\n\t")}");
+
+                        ReadOnlyCollection<UsbInterfaceInfo> interfaceList = configInfo.Interfaces;
+                        for (int iInterface = 0; iInterface < interfaceList.Count; iInterface++)
                         {
-                            UsbConfigInfo configInfo = usbRegistry.Configs[iConfig];
-                            Console.WriteLine(configInfo.ToString());
+                            UsbInterfaceInfo interfaceInfo = interfaceList[iInterface];
+                            Console.WriteLine($"\t\t{interfaceInfo.ToString().ReplaceLineEndings("\n\t\t")}");
 
-                            ReadOnlyCollection<UsbInterfaceInfo> interfaceList = configInfo.Interfaces;
-                            for (int iInterface = 0; iInterface < interfaceList.Count; iInterface++)
+                            ReadOnlyCollection<UsbEndpointInfo> endpointList = interfaceInfo.Endpoints;
+                            for (int iEndpoint = 0; iEndpoint < endpointList.Count; iEndpoint++)
                             {
-                                UsbInterfaceInfo interfaceInfo = interfaceList[iInterface];
-                                Console.WriteLine(interfaceInfo.ToString());
-
-                                ReadOnlyCollection<UsbEndpointInfo> endpointList = interfaceInfo.Endpoints;
-                                for (int iEndpoint = 0; iEndpoint < endpointList.Count; iEndpoint++)
-                                {
-                                    Console.WriteLine(endpointList[iEndpoint].ToString());
-                                }
+                                Console.WriteLine($"\t\t\tEndpoint: {iEndpoint}");
+                                Console.WriteLine($"\t\t\t{endpointList[iEndpoint].ToString().ReplaceLineEndings("\n\t\t\t")}");
                             }
                         }
-
-                        usbRegistry.Close();
                     }
+
+                    device.Close();
                 }
             }
 

--- a/src/Examples/Show.Info/ShowInfo.cs
+++ b/src/Examples/Show.Info/ShowInfo.cs
@@ -22,7 +22,8 @@ namespace Examples
                     Console.Write($"LocationId: {device.BusNumber}");
                     for (int i = 0; i < device.PortNumbers.Count; i++)
                     {
-                        Console.Write('-');
+                        if (i == 0)
+                            Console.Write('-');
                         Console.Write(device.PortNumbers[i]);
                         if (i != device.PortNumbers.Count - 1)
                             Console.Write('.');
@@ -52,6 +53,7 @@ namespace Examples
                     }
 
                     device.Close();
+                    Console.WriteLine(new string ('-', 50));
                 }
             }
 

--- a/src/Examples/Show.Info/ShowInfo.cs
+++ b/src/Examples/Show.Info/ShowInfo.cs
@@ -31,7 +31,10 @@ namespace Examples
                     Console.WriteLine();
                     
                     if (!openedDevice)
+                    {
+                        Console.WriteLine(new string ('-', 50));
                         continue;
+                    }
                     
                     foreach (var configInfo in device.Configs)
                     {

--- a/src/Examples/Show.Info/ShowInfo.cs
+++ b/src/Examples/Show.Info/ShowInfo.cs
@@ -19,6 +19,16 @@ namespace Examples
 
                     Console.WriteLine(device.Info.ToString());
                     
+                    Console.Write($"LocationId: {device.BusNumber}");
+                    for (int i = 0; i < device.PortNumbers.Count; i++)
+                    {
+                        Console.Write('-');
+                        Console.Write(device.PortNumbers[i]);
+                        if (i != device.PortNumbers.Count - 1)
+                            Console.Write('.');
+                    }
+                    Console.WriteLine();
+                    
                     if (!openedDevice)
                         continue;
                     

--- a/src/LibUsbDotNet/Info/UsbConfigInfo.cs
+++ b/src/LibUsbDotNet/Info/UsbConfigInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright ï¿½ 2006-2010 Travis Robinson. All rights reserved.
 //
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -36,26 +36,27 @@ namespace LibUsbDotNet.Info
         {
             Debug.Assert(descriptor.DescriptorType == (int)DescriptorType.Config, "A config descriptor was expected");
 
-            UsbConfigInfo value = new UsbConfigInfo();
-            value.Attributes = descriptor.Attributes;
-            value.Configuration = device.GetStringDescriptor(descriptor.Configuration, failSilently: true);
-            value.ConfigurationValue = descriptor.ConfigurationValue;
+            var value = new UsbConfigInfo
+            {
+                Attributes = descriptor.Attributes,
+                Configuration = device.GetStringDescriptor(descriptor.Configuration, failSilently: true),
+                ConfigurationValue = descriptor.ConfigurationValue,
+                MaxPower = descriptor.MaxPower,
+                RawDescriptors = new byte[descriptor.ExtraLength]
+            };
 
-            value.RawDescriptors = new byte[descriptor.ExtraLength];
             if (descriptor.ExtraLength > 0)
             {
                 Span<byte> extra = new Span<byte>(descriptor.Extra, descriptor.ExtraLength);
                 extra.CopyTo(value.RawDescriptors);
             }
-
-            var interfaces = (Interface*)descriptor.Interface;
+            
+            var interfaces = descriptor.Interface;
             for (int i = 0; i < descriptor.NumInterfaces; i++)
             {
                 var values = UsbInterfaceInfo.FromUsbInterface(device, interfaces[i]);
                 value.interfaces.AddRange(values);
             }
-
-            value.MaxPower = descriptor.MaxPower;
 
             return value;
         }
@@ -77,9 +78,10 @@ namespace LibUsbDotNet.Info
         }
 
         /// <inheritdoc/>
-        public override string ToString()
-        {
-            return this.Configuration;
-        }
+        public override string ToString() =>
+            $"Configuration: {Configuration}\n" +
+            $"Attributes: 0x{Attributes:X2}\n" +
+            $"ConfigurationValue: {ConfigurationValue}\n" +
+            $"MaxPower: {MaxPower}";
     }
 }

--- a/src/LibUsbDotNet/Info/UsbDeviceInfo.cs
+++ b/src/LibUsbDotNet/Info/UsbDeviceInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright ï¿½ 2006-2010 Travis Robinson. All rights reserved.
 //
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -40,15 +40,21 @@ namespace LibUsbDotNet.Info
         {
             Debug.Assert(descriptor.DescriptorType == (int)DescriptorType.Device, "A config descriptor was expected");
 
-            var value = new UsbDeviceInfo();
-            value.Device = descriptor.Device;
-            value.DeviceClass = descriptor.DeviceClass;
-            value.DeviceProtocol = descriptor.DeviceProtocol;
-            value.DeviceSubClass = descriptor.DeviceSubClass;
-            value.ProductId = descriptor.IdProduct;
-            value.VendorId = descriptor.IdVendor;
-            value.Manufacturer = device.GetStringDescriptor(descriptor.Manufacturer, failSilently: true);
-            value.MaxPacketSize0 = descriptor.MaxPacketSize0;
+            var value = new UsbDeviceInfo
+            {
+                Device = descriptor.Device,
+                DeviceClass = descriptor.DeviceClass,
+                DeviceProtocol = descriptor.DeviceProtocol,
+                DeviceSubClass = descriptor.DeviceSubClass,
+                ProductId = descriptor.IdProduct,
+                VendorId = descriptor.IdVendor,
+                Manufacturer = device.GetStringDescriptor(descriptor.Manufacturer, failSilently: true),
+                MaxPacketSize0 = descriptor.MaxPacketSize0,
+                NumConfigurations = descriptor.NumConfigurations,
+                Product = device.GetStringDescriptor(descriptor.Product, failSilently: true),
+                SerialNumber = device.GetStringDescriptor(descriptor.SerialNumber, failSilently: true),
+                Usb = descriptor.USB
+            };
 
             for (byte i = 0; i < descriptor.NumConfigurations; i++)
             {
@@ -57,10 +63,7 @@ namespace LibUsbDotNet.Info
                     value.configurations.Add(configDescriptor);
                 }
             }
-
-            value.Product = device.GetStringDescriptor(descriptor.Product, failSilently: true);
-            value.SerialNumber = device.GetStringDescriptor(descriptor.SerialNumber, failSilently: true);
-            value.Usb = descriptor.USB;
+            
             return value;
         }
 
@@ -84,25 +87,23 @@ namespace LibUsbDotNet.Info
 
         public virtual string Product { get; protected set; }
 
-        public virtual string SerialNumber { get; protected set; }
+        public virtual string SerialNumber { get; protected set; } = string.Empty;
 
         public virtual ushort Usb { get; protected set; }
 
-        public virtual ReadOnlyCollection<UsbConfigInfo> Configurations
-        {
-            get { return new ReadOnlyCollection<UsbConfigInfo>(this.configurations); }
-        }
+        public virtual ReadOnlyCollection<UsbConfigInfo> Configurations => new(this.configurations);
 
-        public override string ToString()
-        {
-            if (!string.IsNullOrEmpty(this.SerialNumber))
-            {
-                return $"{this.Manufacturer} {this.Product} ({this.SerialNumber})";
-            }
-            else
-            {
-                return $"{this.Manufacturer} {this.Product}";
-            }
-        }
+        public override string ToString() =>
+            $"Device: 0x{Device:X4}\n" +
+            $"DeviceClass: {DeviceClass}\n" +
+            $"DeviceSubClass: 0x{DeviceSubClass:X2}\n" +
+            $"VendorId: 0x{VendorId:X4}\n" +
+            $"ProductId: 0x{ProductId:X4}\n" +
+            $"Manufacturer: {Manufacturer}\n" +
+            $"Product: {Product}\n" +
+            $"SerialNumber: {SerialNumber}\n" +
+            $"USB: 0x{Usb:X4}\n" +
+            $"MaxPacketSize: {MaxPacketSize0}\n" +
+            $"NumConfigurations: {NumConfigurations}";
     }
 }

--- a/src/LibUsbDotNet/Info/UsbEndpointInfo.cs
+++ b/src/LibUsbDotNet/Info/UsbEndpointInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2006-2010 Travis Robinson. All rights reserved.
+// Copyright ï¿½ 2006-2010 Travis Robinson. All rights reserved.
 //
 // website: http://sourceforge.net/projects/libusbdotnet
 // e-mail:  libusbdotnet@gmail.com
@@ -32,21 +32,22 @@ namespace LibUsbDotNet.Info
         {
             Debug.Assert(descriptor.DescriptorType == (int)DescriptorType.Endpoint, "An endpoint descriptor was expected");
 
-            var value = new UsbEndpointInfo();
-            value.Attributes = descriptor.Attributes;
-            value.EndpointAddress = descriptor.EndpointAddress;
+            var value = new UsbEndpointInfo
+            {
+                Attributes = descriptor.Attributes,
+                EndpointAddress = descriptor.EndpointAddress,
+                RawDescriptors = new byte[descriptor.ExtraLength],
+                Interval = descriptor.Interval,
+                MaxPacketSize = descriptor.MaxPacketSize,
+                Refresh = descriptor.Refresh,
+                SyncAddress = descriptor.SynchAddress
+            };
 
-            value.RawDescriptors = new byte[descriptor.ExtraLength];
             if (descriptor.ExtraLength > 0)
             {
                 Span<byte> extra = new Span<byte>(descriptor.Extra, descriptor.ExtraLength);
                 extra.CopyTo(value.RawDescriptors);
             }
-
-            value.Interval = descriptor.Interval;
-            value.MaxPacketSize = descriptor.MaxPacketSize;
-            value.Refresh = descriptor.Refresh;
-            value.SyncAddress = descriptor.SynchAddress;
 
             return value;
         }
@@ -63,9 +64,11 @@ namespace LibUsbDotNet.Info
 
         public virtual byte SyncAddress { get; private set; }
 
-        public override string ToString()
-        {
-            return $"{this.EndpointAddress}";
-        }
+        public override string ToString() =>
+            $"Address: 0x{EndpointAddress:X2}\n" +
+            $"Interval: {Interval}\n" +
+            $"MaxPacketSize: {MaxPacketSize}\n" +
+            $"Refresh: {Refresh}\n" +
+            $"SyncAddress: 0x{SyncAddress:X2}";
     }
 }


### PR DESCRIPTION
Fixes issue #187. I made the ToString methods of the various device info classes more verbose, let me know if we would rather put these in extra methods for those classes. 

Also switched to using object initializers for the info classes, just a code style thing.

If I messed up the format or order of any of the properties, let me know.

Sample output:

```
Device: 0x0100
DeviceClass: 0
DeviceSubClass: 0x00
VendorId: 0x04B4
ProductId: 0x00F3
Manufacturer: Cypress
Product: WestBridge 
SerialNumber: 0000000004BE
USB: 0x0200
MaxPacketSize: 64
NumConfigurations: 1
        Configuration: 
        Attributes: 0x80
        ConfigurationValue: 1
        MaxPower: 100
                Interface: 
                InterfaceId: 0
                AlternateId: 0
                Class: VendorSpec
                Protocol: 0x00
                SubClass: 0x00
Device: 0x0602
DeviceClass: 9
DeviceSubClass: 0x00
VendorId: 0x1D6B
ProductId: 0x0002
Manufacturer: Linux 6.2.9-200.fc37.x86_64 xhci-hcd
Product: xHCI Host Controller
SerialNumber: 0000:0c:00.3
USB: 0x0200
MaxPacketSize: 64
NumConfigurations: 1
        Configuration: 
        Attributes: 0xE0
        ConfigurationValue: 1
        MaxPower: 0
                Interface: 
                InterfaceId: 0
                AlternateId: 0
                Class: Hub
                Protocol: 0x00
                SubClass: 0x00
                        Endpoint: 0
                        Address: 0x81
                        Interval: 12
                        MaxPacketSize: 4
                        Refresh: 0
                        SyncAddress: 0x00

```