### PR TITLE
Updated solution file to open with VS2022.

### DIFF
--- a/stage/LibUsbDotNet.sln
+++ b/stage/LibUsbDotNet.sln
@@ -1,35 +1,35 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{5E024A6D-DD45-421A-BF51-73DBA0A27E53}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_Bulk", "Test_Bulk\Test_Bulk.csproj", "{2AA77B1D-5F6B-4206-954C-ED8D6E7DEA1B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test_Bulk", "Test_Bulk\Test_Bulk.csproj", "{2AA77B1D-5F6B-4206-954C-ED8D6E7DEA1B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{A379842D-C4E3-41E1-BE82-4041293AC225}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "Benchmark\Benchmark.csproj", "{A379842D-C4E3-41E1-BE82-4041293AC225}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_DeviceNotify", "Test_DeviceNotify\Test_DeviceNotify.csproj", "{7E081E3A-C557-4303-93EB-FFE2DA8DAB68}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test_DeviceNotify", "Test_DeviceNotify\Test_DeviceNotify.csproj", "{7E081E3A-C557-4303-93EB-FFE2DA8DAB68}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_Info", "Test_Info\Test_Info.csproj", "{3EFEDA92-CAE3-4585-A519-439ACD58468A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test_Info", "Test_Info\Test_Info.csproj", "{3EFEDA92-CAE3-4585-A519-439ACD58468A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Write", "Examples\Read.Write\Read.Write.csproj", "{4030AC2F-4073-4F33-A529-6AF5B5D99B45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Write", "Examples\Read.Write\Read.Write.csproj", "{4030AC2F-4073-4F33-A529-6AF5B5D99B45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Write.Event", "Examples\Read.Write.Event\Read.Write.Event.csproj", "{CCDBE804-2312-444D-B7E7-C63FF1469795}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Write.Event", "Examples\Read.Write.Event\Read.Write.Event.csproj", "{CCDBE804-2312-444D-B7E7-C63FF1469795}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Device.Notification", "Examples\Device.Notification\Device.Notification.csproj", "{A893CFAA-FCDF-4055-A8D4-435CDE59445F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Device.Notification", "Examples\Device.Notification\Device.Notification.csproj", "{A893CFAA-FCDF-4055-A8D4-435CDE59445F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Only", "Examples\Read.Only\Read.Only.csproj", "{1133D96A-E8E5-4C70-8E17-B9226A78093C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Only", "Examples\Read.Only\Read.Only.csproj", "{1133D96A-E8E5-4C70-8E17-B9226A78093C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Show.Info", "Examples\Show.Info\Show.Info.csproj", "{F7069C5F-8327-471A-9C13-9764C11E3A56}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Show.Info", "Examples\Show.Info\Show.Info.csproj", "{F7069C5F-8327-471A-9C13-9764C11E3A56}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Write.Async", "Examples\Read.Write.Async\Read.Write.Async.csproj", "{C67D8BD5-18C4-4D1D-83E6-03E04660884D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Write.Async", "Examples\Read.Write.Async\Read.Write.Async.csproj", "{C67D8BD5-18C4-4D1D-83E6-03E04660884D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkCon", "BenchmarkCon\BenchmarkCon.csproj", "{D1D2E921-F735-4D04-B6B4-6F9A4B70F749}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkCon", "BenchmarkCon\BenchmarkCon.csproj", "{D1D2E921-F735-4D04-B6B4-6F9A4B70F749}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Read.Isochronous", "Examples\Read.Isochronous\Read.Isochronous.csproj", "{4581EC5B-EB14-4B1A-A85B-9D3B1087DBBE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Isochronous", "Examples\Read.Isochronous\Read.Isochronous.csproj", "{4581EC5B-EB14-4B1A-A85B-9D3B1087DBBE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibUsbDotNet", "LibUsbDotNet\LibUsbDotNet.csproj", "{0A78F6FF-5586-4052-8104-E23FF83A7CE1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibUsbDotNet", "LibUsbDotNet\LibUsbDotNet.csproj", "{0A78F6FF-5586-4052-8104-E23FF83A7CE1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I have multiple versions of VS installed (2017, 2019, 2022) on my system. By default (double click) the solution opens with VS2017 which cannot build it. Hence the changes to the solution file to open with VS2022.

NOTE: Project type GUIDs were automatically updated by Visual Studio.

`FAE04EC0-301F-11D3-BF4B-00C04F79EFBC` C#
`9A19103F-16F7-4668-BE54-9A1E7A4F7556` C# (forces use of [SDK project system](https://github.com/dotnet/project-system/blob/master/docs/opening-with-new-project-system.md#project-type-guids))