### PR TITLE
NET 8.0 build for V2.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -142,7 +142,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Install libusb
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Build
         run: dotnet build .\stage\LibUsbDotNet\LibUsbDotNet.csproj -c Release
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Build
         run: dotnet build ./stage/LibUsbDotNet/LibUsbDotNet.csproj -c Release

--- a/stage/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/stage/LibUsbDotNet/LibUsbDotNet.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>LibUsbDotNet for .NET Core</AssemblyTitle>
     <VersionPrefix>2.2.9</VersionPrefix>
     <Authors>Travis Robinson;Stevie-O;Quamotion</Authors>
-    <TargetFrameworks>netstandard2.0;net46;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBUSBDOTNET</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>LibUsbDotNet.LibUsbDotNet</AssemblyName>

--- a/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
+++ b/stage/LibUsbDotNet/Main/UsbDeviceFinder.cs
@@ -26,6 +26,9 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace LibUsbDotNet.Main
 {
@@ -248,7 +251,7 @@ namespace LibUsbDotNet.Main
 #endregion
 #endif
 
-#if !NETSTANDARD1_5 && !NETSTANDARD1_6
+#if !NETSTANDARD1_5 && !NETSTANDARD1_6 && !NET8_0_OR_GREATER
         /// <summary>
         /// Load usb device finder properties from a binary stream.
         /// </summary>
@@ -270,6 +273,29 @@ namespace LibUsbDotNet.Main
         {
             BinaryFormatter formatter = new BinaryFormatter();
             formatter.Serialize(outStream, usbDeviceFinder);
+        }
+#endif
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Load usb device finder properties from a binary stream.
+        /// </summary>
+        /// <param name="deviceFinderStream">The binary stream containing a
+        /// <see cref="UsbDeviceFinder"/> </param> instance.
+        /// <returns>A pre-loaded <see cref="UsbDeviceFinder"/> instance.</returns>
+        public static UsbDeviceFinder Load(Stream deviceFinderStream)
+        {
+            return JsonSerializer.Deserialize<UsbDeviceFinder>(deviceFinderStream);
+        }
+
+        /// <summary>
+        /// Saves a <see cref="UsbDeviceFinder"/> instance to a stream.
+        /// </summary>
+        /// <param name="usbDeviceFinder"></param>
+        /// <param name="outStream"></param>
+        public static void Save(UsbDeviceFinder usbDeviceFinder, Stream outStream)
+        {
+            JsonSerializer.Serialize(outStream, usbDeviceFinder);
         }
 #endif
 


### PR DESCRIPTION
It seems that the only issue is the removal of BinaryFormatter from Net 8.0 (was already deprecated).

In V2, the BinaryFormatter is only used for some Load/Save methods inside the UsbDeviceFinder class. 
While I do not use that particular class myself, so I haven't really tested it (even if I were to use it, Saving and Loading finder objects does not seem to be used all that much/all that useful), I did replace the existing Serializer with JsonSerializer and that should work just fine.

#236 