### PR TITLE
Updating download location for libusb-win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 All basic USB device functionality can be performed through common device classes allowing you to write OS and driver independent code.
 
 * LibUsbDotNet versions 2.2.4 and above support the Libusb-1.0 driver.
-* LibUsbDotNet 2.1.0 and above supports the genuine [libusb-win32](http://sourceforge.net/projects/libusb-win32) driver package. However, 
+* LibUsbDotNet 2.1.0 and above supports the genuine [libusb-win32](https://github.com/mcuee/libusb-win32/releases) driver package. However, 
   access to basic device information via the windows registry is not available. See the [LegacyUsbRegistry](http://libusbdotnet.sourceforge.net/V2/html/9b8a7337-0d0c-c3e6-6f56-d47f1a3e5856.htm)
   class for more information.
 


### PR DESCRIPTION
Updating download location for libusb-win32 to pass along the redirect given from the sourceforge download link. 

Sourceforge download content:
Sourceforge will only be used for mailing list since Feb 2024. Please go to https://github.com/mcuee/libusb-win32/releases to  download the latest official releases.