### PR TITLE
Make control transfer timeout configurable in MonoUsbDevice

### DIFF
--- a/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
+++ b/stage/LibUsbDotNet/MonoLibUsb/MonoUsbDevice.cs
@@ -45,6 +45,8 @@ namespace LibUsbDotNet.LudnMonoLibUsb
         internal static MonoUsbProfileList mMonoUSBProfileList;
         private readonly MonoUsbProfile mMonoUSBProfile;
 
+        public static int ControlTransferTimeout_ms { get; set; } = UsbConstants.DEFAULT_TIMEOUT;
+
         internal MonoUsbDevice(ref MonoUsbProfile monoUSBProfile)
             : base(null, null)
         {
@@ -195,7 +197,7 @@ namespace LibUsbDotNet.LudnMonoLibUsb
                                                       setupPacket.Index,
                                                       buffer,
                                                       (short)bufferLength,
-                                                      UsbConstants.DEFAULT_TIMEOUT);
+                                                      ControlTransferTimeout_ms);
 
             Debug.WriteLine(GetType().Name + ".ControlTransfer() Error:" + ((MonoUsbError)ret).ToString(), "Libusb-1.0");
             if (ret < 0)


### PR DESCRIPTION
Hi,
I'm using LibUsbDotNet to talk to STM32 DfuSe devices. Using the default DFU implementation by ST, the whole communication is expected to be done using control transfers.
Due to hardware limitations, execution of some DFU commands on the embedded device might take longer than 1000ms. This results in a timeout error due to the timeout being hard coded in LibUsbDotNet.

This small change fixes my problem and has no impact on other users, because the default behavior is unchanged.

Please consider my PR as a suggestion. I think, it could be helpful for other users, too, but I explicitly don't require you to merge it.

Best regards,
Michael