### PR TITLE
Artifacts v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - artifacts-v4
   pull_request:
 
 jobs:


### PR DESCRIPTION
Fixes the build pipeline by upgrading the artifact actions to use v4 (v3 is officially deprecated). Also fixes issues with macos build #260 .

[Successful run on my fork](https://github.com/sdijoseph/LibUsbDotNet/actions/runs/14325904347)