### PR TITLE
Dependabot: Add github actions configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Although as per https://github.com/LibUsbDotNet/LibUsbDotNet/issues/277 dependabot may not be turned on for the time being, I will be running it for my fork so that I get update notifications.

For this reason I would like to contribute this dependabot configuration so that if other people wants to do the same, we may share a common config.

For the time being, the dependabot config only covers github actions as I do not have much experience with the dotnet/nuget/vs ecosystems and I will need to test and tweak things.