### PR TITLE
Avoid hard-coded package references

### DIFF
--- a/src/TestInfo/TestInfo.csproj
+++ b/src/TestInfo/TestInfo.csproj
@@ -26,10 +26,13 @@
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="LibUsbDotNet" Version="3.0" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.1.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LibUsbDotNet\LibUsbDotNet.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will improve the experience of building this project and ensure all projects reference the correct dependency versions.