### PR TITLE
Avoid pulling non-canonical dependencies

### DIFF
--- a/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
+++ b/src/LibUsbDotNet.Generator/LibUsbDotNet.Generator.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Core.Clang" Version="6.0.0-alpha1" />
-    <PackageReference Include="Native.LibClang.win-x64" Version="5.0.0-alpha1" />
-    <PackageReference Include="Nustache" Version="1.16.0.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp " Version="2.9.0" />
+    <PackageReference Include="Native.LibClang.win-x64" Version="6.0.0-alpha2" />
+    <PackageReference Include="Nustache" Version="1.16.0.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp " Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
+++ b/src/LibUsbDotNet.Tests/LibUsbDotNet.Tests.csproj
@@ -9,9 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibUsbDotNet/LibUsbDotNet.csproj
+++ b/src/LibUsbDotNet/LibUsbDotNet.csproj
@@ -25,14 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="IndexRange" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Nullable" Version="1.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -44,8 +39,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
All required types to build this project are now pulled from official sources. This should improve maintainability and reproducible builds in the future.

All core package dependencies have also been updated to their latest versions.