### PR TITLE
Update docs.yml to use dotnet V8 and bump action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - name: Setup .NET 7.0
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Setup DocFX
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v4
         with:
           args: install docfx
 
@@ -35,7 +35,7 @@ jobs:
         
       - name: Publish
         if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docfx_project/_site


### PR DESCRIPTION
1) Use dotnet 8.0 as 7.0 is no longer supported.
2) actions/checkout: v2  → v6
3) actions/setup-dotnet: v1  → v5
4) crazy-max/ghaction-chocolatey: v1  → v4
5) peaceiris/actions-gh-pages: v3  → v4