### PR TITLE
Change `UsbEndpointWriter.Write` to take ReadOnlySpan

### DIFF
--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -120,6 +120,16 @@ public abstract class UsbEndpointBase
             // copy it to a temporary buffer and pass it to Transfer(Span<byte>).
             // The write is performed on the temporary buffer, so it
             // does not affect the original ReadOnlySpan<byte>.
+            //
+            // Furthermore, since the native API `libusb_bulk_transfer` and `libusb_interrupt_transfer`
+            // called by the `Transfer` method handle both outgoing and incoming transfers.
+            // Their pointer parameters are of type `unsigned char*`, meaning they
+            // are writable.
+            // Moreover, the documentation contains no explicit statement that they
+            // never write to the buffer during outbound transfers.
+            //
+            // Therefore, to ensure that the provided buffer is read-only, we copy the data
+            // to a temporary buffer here.
             readOnlyBuffer.CopyTo(buffer);
 
             return Transfer(buffer.AsSpan(0, readOnlyBuffer.Length), timeout, out transferLength);
@@ -200,6 +210,17 @@ public abstract class UsbEndpointBase
             // copy it to a temporary buffer and pass it to TransferAsync(Memory<byte>).
             // The write is performed on the temporary buffer, so it
             // does not affect the original ReadOnlyMemory<byte>.
+            //
+            // Furthermore, the native API `libusb_submit_transfer`, which is called by
+            // the `AsyncTransfer.TransferAsync` method, is invoked for both outgoing
+            // and incoming transfers. The `buffer` member of its parameter
+            // `struct libusb_transfer` is of type `unsigned char*`, meaning it is
+            // writable.
+            // Moreover, the documentation contains no explicit statement that they
+            // never write to the buffer during outbound transfers.
+            //
+            // Therefore, to ensure that the provided buffer is read-only, we copy the data
+            // to a temporary buffer here.
             readOnlyBuffer.CopyTo(buffer);
 
             return await TransferAsync(buffer.AsMemory(0, readOnlyBuffer.Length), timeout).ConfigureAwait(false);

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -103,6 +103,13 @@ public abstract class UsbEndpointBase
     /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
     /// <param name="transferLength">Number of bytes actually transferred.</param>
     /// <returns>True on success.</returns>
+    /// <remarks>
+    /// This method passes a data buffer (<paramref name="readOnlyBuffer"/>) to the native API,
+    /// but unlike the <see cref="Transfer(Span{byte},int,out int)"/>, it ignores the contents of
+    /// the buffer without copying them, even if data has been written to it.
+    /// If you expect to receive data from the native API and have it written to the original buffer,
+    /// use the <see cref="Transfer(Span{byte},int,out int)"/> method.
+    /// </remarks>
     public virtual Error Transfer(ReadOnlySpan<byte> readOnlyBuffer, int timeout, out int transferLength)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(readOnlyBuffer.Length);
@@ -176,6 +183,13 @@ public abstract class UsbEndpointBase
     /// <param name="readOnlyBuffer">Caller-allocated read-only buffer.</param>
     /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
     /// <returns>Named tuple of <see cref="Error"/> and transferLength</returns>
+    /// <remarks>
+    /// This method passes a data buffer (<paramref name="readOnlyBuffer"/>) to the native API,
+    /// but unlike the <see cref="TransferAsync(Memory{byte},int)"/>, it ignores the contents of
+    /// the buffer without copying them, even if data has been written to it.
+    /// If you expect to receive data from the native API and have it written to the original buffer,
+    /// use the <see cref="TransferAsync(Memory{byte},int)"/> method.
+    /// </remarks>
     protected async Task<(Error error, int transferLength)> TransferAsync(ReadOnlyMemory<byte> readOnlyBuffer, int timeout)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(readOnlyBuffer.Length);

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -23,6 +23,7 @@
 using LibUsbDotNet.Info;
 using LibUsbDotNet.Main;
 using System;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -96,6 +97,33 @@ public abstract class UsbEndpointBase
     }
 
     /// <summary>
+    /// Synchronous bulk/interrupt transfer function for read-only buffers.
+    /// </summary>
+    /// <param name="readOnlyBuffer">An <see cref="ReadOnlySpan{T}"/> to a caller-allocated read-only buffer.</param>
+    /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
+    /// <param name="transferLength">Number of bytes actually transferred.</param>
+    /// <returns>True on success.</returns>
+    public virtual Error Transfer(ReadOnlySpan<byte> readOnlyBuffer, int timeout, out int transferLength)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(readOnlyBuffer.Length);
+
+        try
+        {
+            // To convert a ReadOnlySpan<byte> into a writable Span<byte>,
+            // copy it to a temporary buffer and pass it to Transfer(Span<byte>).
+            // The write is performed on the temporary buffer, so it
+            // does not affect the original ReadOnlySpan<byte>.
+            readOnlyBuffer.CopyTo(buffer);
+
+            return Transfer(buffer.AsSpan(0, readOnlyBuffer.Length), timeout, out transferLength);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
     /// Synchronous bulk/interrupt transfer function.
     /// </summary>
     /// <param name="buffer">A <see cref="Span{T}"/> to a caller-allocated buffer.</param>
@@ -141,6 +169,32 @@ public abstract class UsbEndpointBase
     /// and a <see cref="Error"/> on failure. 
     /// </returns>
     public Error ClearHalt() => NativeMethods.ClearHalt(this.Device.DeviceHandle, this.mEpNum);
+
+    /// <summary>
+    /// Asynchronous bulk/interrupt transfer function for read-only buffers.
+    /// </summary>
+    /// <param name="readOnlyBuffer">Caller-allocated read-only buffer.</param>
+    /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
+    /// <returns>Named tuple of <see cref="Error"/> and transferLength</returns>
+    protected async Task<(Error error, int transferLength)> TransferAsync(ReadOnlyMemory<byte> readOnlyBuffer, int timeout)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(readOnlyBuffer.Length);
+
+        try
+        {
+            // To convert a ReadOnlyMemory<byte> into a writable Memory<byte>,
+            // copy it to a temporary buffer and pass it to TransferAsync(Memory<byte>).
+            // The write is performed on the temporary buffer, so it
+            // does not affect the original ReadOnlyMemory<byte>.
+            readOnlyBuffer.CopyTo(buffer);
+
+            return await TransferAsync(buffer.AsMemory(0, readOnlyBuffer.Length), timeout).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
 
     /// <summary>
     /// Asynchronous bulk/interrupt transfer function.

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
@@ -14,7 +14,7 @@ public partial class UsbEndpointWriter
     /// <returns>
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
-    public virtual async Task<(Error error, int transferLength)> WriteAsync(Memory<byte> buffer, int timeout) => 
+    public virtual async Task<(Error error, int transferLength)> WriteAsync(ReadOnlyMemory<byte> buffer, int timeout) => 
         await TransferAsync(buffer, timeout).ConfigureAwait(false);
 
     /// <summary>
@@ -27,6 +27,6 @@ public partial class UsbEndpointWriter
     /// <returns>
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
-    public virtual async Task<(Error error, int transferLength)> WriteAsync(Memory<byte> buffer, int offset, int length, int timeout) => 
+    public virtual async Task<(Error error, int transferLength)> WriteAsync(ReadOnlyMemory<byte> buffer, int offset, int length, int timeout) => 
         await TransferAsync(buffer.Slice(offset, length), timeout).ConfigureAwait(false);
 }

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace LibUsbDotNet.LibUsb;
 
-/// <summary>Contains methods for writing data to a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Write(Span{byte},int,out int)"/> functions.
+/// <summary>Contains methods for writing data to a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Write(ReadOnlySpan{byte},int,out int)"/> functions.
 /// </summary>
 public partial class UsbEndpointWriter : UsbEndpointBase
 {
@@ -43,7 +43,7 @@ public partial class UsbEndpointWriter : UsbEndpointBase
     /// <returns>
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
-    public virtual Error Write(Span<byte> buffer, int timeout, out int transferLength) => 
+    public virtual Error Write(ReadOnlySpan<byte> buffer, int timeout, out int transferLength) => 
         Transfer(buffer, timeout, out transferLength);
 
     /// <summary>
@@ -57,6 +57,6 @@ public partial class UsbEndpointWriter : UsbEndpointBase
     /// <returns>
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
-    public virtual Error Write(Span<byte> buffer, int offset, int count, int timeout, out int transferLength) => 
+    public virtual Error Write(ReadOnlySpan<byte> buffer, int offset, int count, int timeout, out int transferLength) => 
         Transfer(buffer.Slice(offset, count), timeout, out transferLength);
 }


### PR DESCRIPTION
`UsbEndpointWriter` currently defines `Write` and `WriteAsync` methods that take writable `Span` and `Memory` buffers.
By contrast, APIs that output buffer data—such as `Stream.Write`/`WriteAsync` and `Socket.Send`/`SendAsync`—use `ReadOnlySpan`/`ReadOnlyMemory` to ensure that the provided buffer is treated as read-only.

This PR updates the signatures of `UsbEndpointWriter.Write` and `WriteAsync` to follow this common pattern by switching their parameter types to `ReadOnlySpan`/`ReadOnlyMemory`.

`UsbEndpointBase.Transfer` and `TransferAsync`, which are called internally, currently accept only writable buffers.
To support the updated signatures, new overloads that take read-only buffers are introduced, and the writer methods are updated to call them.
These overloads allocate a writable temporary buffer, copy the input data into it, and perform the transfer without modifying the original read-only buffer.

Closes #283.