### PR TITLE
Fix potential buffer overrun in transfer methods

### DIFF
--- a/src/LibUsbDotNet/LibUsb/AsyncTransfer.cs
+++ b/src/LibUsbDotNet/LibUsb/AsyncTransfer.cs
@@ -63,16 +63,11 @@ internal static class AsyncTransfer
         byte endPoint,
         EndpointType endPointType,
         Memory<byte> buffer,
-        int offset,
-        int length,
         int timeout,
         int isoPacketSize = 0)
     {
         if (device == null) 
             throw new ArgumentNullException(nameof(device));
-
-        if (offset < 0)
-            throw new ArgumentOutOfRangeException(nameof(offset));
 
         int transferId;
         
@@ -96,7 +91,7 @@ internal static class AsyncTransfer
         int numIsoPackets = 0;
 
         if (isoPacketSize > 0)
-            numIsoPackets = length / isoPacketSize;
+            numIsoPackets = buffer.Length / isoPacketSize;
 
         var transfer = NativeMethods.AllocTransfer(numIsoPackets); // TODO: Check if transfer is null.
 
@@ -105,8 +100,8 @@ internal static class AsyncTransfer
         transfer->Endpoint = endPoint;
         transfer->Timeout = (uint)timeout;
         transfer->Type = (byte)endPointType;
-        transfer->Buffer = (byte*)memoryHandle.Pointer + offset;
-        transfer->Length = length;
+        transfer->Buffer = (byte*)memoryHandle.Pointer;
+        transfer->Length = buffer.Length;
         transfer->NumIsoPackets = numIsoPackets;
         transfer->Flags = (byte)TransferFlags.None;
         transfer->Callback = TransferDelegatePtr;

--- a/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbDevice.DeviceHandle.Async.cs
@@ -32,7 +32,7 @@ public partial class UsbDevice
         Array.Copy(BitConverter.GetBytes(setupPacket.Index), 0, data, 4, 2);
         Array.Copy(BitConverter.GetBytes(setupPacket.Length), 0, data, 6, 2);
 
-        (Error error, int dataTransferred) = await AsyncTransfer.TransferAsync(deviceHandle, 0, EndpointType.Control, data, 0, data.Length, ControlTransferTimeout).ConfigureAwait(false);
+        (Error error, int dataTransferred) = await AsyncTransfer.TransferAsync(deviceHandle, 0, EndpointType.Control, data.AsMemory(), ControlTransferTimeout).ConfigureAwait(false);
 
         error.ThrowOnError();
 

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -98,7 +98,7 @@ public abstract class UsbEndpointBase
     /// <summary>
     /// Synchronous bulk/interrupt transfer function.
     /// </summary>
-    /// <param name="buffer">A <see cref="Span{byte}"/> to a caller-allocated buffer.</param>
+    /// <param name="buffer">A <see cref="Span{T}"/> to a caller-allocated buffer.</param>
     /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
     /// <param name="transferLength">Number of bytes actually transferred.</param>
     /// <returns>True on success.</returns>

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs
@@ -98,13 +98,11 @@ public abstract class UsbEndpointBase
     /// <summary>
     /// Synchronous bulk/interrupt transfer function.
     /// </summary>
-    /// <param name="buffer">An <see cref="IntPtr"/> to a caller-allocated buffer.</param>
-    /// <param name="offset">Position in buffer that transferring begins.</param>
-    /// <param name="length">Number of bytes, starting from thr offset parameter to transfer.</param>
+    /// <param name="buffer">A <see cref="Span{byte}"/> to a caller-allocated buffer.</param>
     /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
     /// <param name="transferLength">Number of bytes actually transferred.</param>
     /// <returns>True on success.</returns>
-    public virtual unsafe Error Transfer(Span<byte> buffer, int offset, int length, int timeout, out int transferLength)
+    public virtual unsafe Error Transfer(Span<byte> buffer, int timeout, out int transferLength)
     {
         int transferred = 0;
 
@@ -113,13 +111,13 @@ public abstract class UsbEndpointBase
         {
             case EndpointType.Bulk:
                 fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
-                    returnValue = NativeMethods.BulkTransfer(this.Device.DeviceHandle, this.mEpNum, bufferPtr + offset, length, ref transferred, (uint)timeout);
+                    returnValue = NativeMethods.BulkTransfer(this.Device.DeviceHandle, this.mEpNum, bufferPtr, buffer.Length, ref transferred, (uint)timeout);
                 transferLength = transferred;
                 return returnValue;
 
             case EndpointType.Interrupt:
                 fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
-                    returnValue = NativeMethods.InterruptTransfer(this.Device.DeviceHandle, this.mEpNum, bufferPtr + offset, length, ref transferred, (uint)timeout);
+                    returnValue = NativeMethods.InterruptTransfer(this.Device.DeviceHandle, this.mEpNum, bufferPtr, buffer.Length, ref transferred, (uint)timeout);
                 transferLength = transferred;
                 return returnValue;
 
@@ -148,12 +146,10 @@ public abstract class UsbEndpointBase
     /// Asynchronous bulk/interrupt transfer function.
     /// </summary>
     /// <param name="buffer">Caller-allocated buffer.</param>
-    /// <param name="offset">Position in buffer that transferring begins.</param>
-    /// <param name="length">Number of bytes, starting from thr offset parameter to transfer.</param>
     /// <param name="timeout">Maximum time to wait for the transfer to complete.</param>
     /// <returns>Named tuple of <see cref="Error"/> and transferLength</returns>
-    protected Task<(Error error, int transferLength)> TransferAsync(Memory<byte> buffer, int offset, int length, int timeout) => 
-        AsyncTransfer.TransferAsync(this.Device.DeviceHandle, this.mEpNum, this.mEndpointType, buffer, offset, length, timeout);
+    protected Task<(Error error, int transferLength)> TransferAsync(Memory<byte> buffer, int timeout) => 
+        AsyncTransfer.TransferAsync(this.Device.DeviceHandle, this.mEpNum, this.mEndpointType, buffer, timeout);
 
     /// <summary>
     /// Looks up endpoint/interface information in a configuration.

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointReader.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointReader.Async.cs
@@ -13,30 +13,6 @@ public partial class UsbEndpointReader
         /// <returns>
         /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
         /// </returns>
-        public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int timeout) => 
-            await ReadAsync(buffer.AsMemory(0, buffer.Length), timeout).ConfigureAwait(false);
-
-        /// <summary>
-        /// Reads data asynchronously from the current <see cref="UsbEndpointReader"/>.
-        /// </summary>
-        /// <param name="buffer">The buffer to store the received data in.</param>
-        /// <param name="offset">The position in buffer to start storing the data.</param>
-        /// <param name="length">The maximum number of bytes to receive.</param>
-        /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-        /// <returns>
-        /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
-        /// </returns>
-        public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int offset, int length, int timeout) => 
-            await TransferAsync(buffer.AsMemory(offset, length), timeout).ConfigureAwait(false);
-        
-        /// <summary>
-        /// Reads data asynchronously from the current <see cref="UsbEndpointReader"/>.
-        /// </summary>
-        /// <param name="buffer">The buffer to store the received data in.</param>
-        /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-        /// <returns>
-        /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
-        /// </returns>
         public virtual async Task<(Error error, int transferLength)> ReadAsync(Memory<byte> buffer, int timeout) => 
             await TransferAsync(buffer, timeout).ConfigureAwait(false);
         

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointReader.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointReader.Async.cs
@@ -14,7 +14,7 @@ public partial class UsbEndpointReader
         /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
         /// </returns>
         public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int timeout) => 
-            await ReadAsync(buffer, 0, buffer.Length, timeout).ConfigureAwait(false);
+            await ReadAsync(buffer.AsMemory(0, buffer.Length), timeout).ConfigureAwait(false);
 
         /// <summary>
         /// Reads data asynchronously from the current <see cref="UsbEndpointReader"/>.
@@ -27,7 +27,7 @@ public partial class UsbEndpointReader
         /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
         /// </returns>
         public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int offset, int length, int timeout) => 
-            await TransferAsync(buffer, offset, length, timeout).ConfigureAwait(false);
+            await TransferAsync(buffer.AsMemory(offset, length), timeout).ConfigureAwait(false);
         
         /// <summary>
         /// Reads data asynchronously from the current <see cref="UsbEndpointReader"/>.
@@ -38,7 +38,7 @@ public partial class UsbEndpointReader
         /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
         /// </returns>
         public virtual async Task<(Error error, int transferLength)> ReadAsync(Memory<byte> buffer, int timeout) => 
-            await ReadAsync(buffer, 0, buffer.Length, timeout).ConfigureAwait(false);
+            await TransferAsync(buffer, timeout).ConfigureAwait(false);
         
         /// <summary>
         /// Reads data asynchronously from the current <see cref="UsbEndpointReader"/>.
@@ -51,7 +51,7 @@ public partial class UsbEndpointReader
         /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
         /// </returns>
         public virtual async Task<(Error error, int transferLength)> ReadAsync(Memory<byte> buffer, int offset, int length, int timeout) => 
-            await TransferAsync(buffer, offset, length, timeout).ConfigureAwait(false);
+            await TransferAsync(buffer.Slice(offset, length), timeout).ConfigureAwait(false);
 
         /// <summary>
         /// Reads/discards data asynchronously from the endpoint until no more data is available.

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
@@ -80,7 +80,7 @@ public partial class UsbEndpointReader : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Read(byte[] buffer, int offset, int count, int timeout, out int transferLength) 
-        => Transfer(buffer, offset, count, timeout, out transferLength);
+        => Transfer(buffer.AsSpan(offset, count), timeout, out transferLength);
 
     /// <summary>
     /// Reads data from the current <see cref="UsbEndpointReader"/>.
@@ -92,7 +92,7 @@ public partial class UsbEndpointReader : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Read(Span<byte> buffer, int timeout, out int transferLength) 
-        => Read(buffer, 0, buffer.Length, timeout, out transferLength);
+        => Transfer(buffer, timeout, out transferLength);
 
     /// <summary>
     /// Reads data from the current <see cref="UsbEndpointReader"/>.
@@ -106,7 +106,7 @@ public partial class UsbEndpointReader : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Read(Span<byte> buffer, int offset, int count, int timeout, out int transferLength) 
-        => Transfer(buffer, offset, count, timeout, out transferLength);
+        => Transfer(buffer.Slice(offset, count), timeout, out transferLength);
 
     /// <summary>
     /// Reads/discards data from the endpoint until no more data is available.

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointReader.cs
@@ -27,7 +27,7 @@ using LibUsbDotNet.Main;
 namespace LibUsbDotNet.LibUsb;
 
 /// <summary>
-/// Contains methods for retrieving data from a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Read(byte[],int,out int)"/> functions.
+/// Contains methods for retrieving data from a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Read(Span{byte},int,out int)"/> functions.
 /// </summary>
 public partial class UsbEndpointReader : UsbEndpointBase
 {
@@ -55,32 +55,6 @@ public partial class UsbEndpointReader : UsbEndpointBase
     /// The default is 4096.
     /// </remarks>
     public static int DefReadBufferSize { get; set; } = 4096;
-
-    /// <summary>
-    /// Reads data from the current <see cref="UsbEndpointReader"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer to store the received data in.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <param name="transferLength">Number of bytes actually transferred.</param>
-    /// <returns>
-    /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
-    /// </returns>
-    public virtual Error Read(byte[] buffer, int timeout, out int transferLength) 
-        => Read(buffer, 0, buffer.Length, timeout, out transferLength);
-
-    /// <summary>
-    /// Reads data from the current <see cref="UsbEndpointReader"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer to store the received data in.</param>
-    /// <param name="offset">The position in buffer to start storing the data.</param>
-    /// <param name="count">The maximum number of bytes to receive.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <param name="transferLength">Number of bytes actually transferred.</param>
-    /// <returns>
-    /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
-    /// </returns>
-    public virtual Error Read(byte[] buffer, int offset, int count, int timeout, out int transferLength) 
-        => Transfer(buffer.AsSpan(offset, count), timeout, out transferLength);
 
     /// <summary>
     /// Reads data from the current <see cref="UsbEndpointReader"/>.

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
@@ -14,30 +14,6 @@ public partial class UsbEndpointWriter
     /// <returns>
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
-    public virtual async Task<(Error error, int transferLength)> WriteAsync(byte[] buffer, int timeout) => 
-        await WriteAsync(buffer, 0, buffer.Length, timeout).ConfigureAwait(false);
-
-    /// <summary>
-    /// Writes data asynchronously to the current <see cref="UsbEndpointWriter"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer storing the data to write.</param>
-    /// <param name="offset">The position in buffer to start writing the data from.</param>
-    /// <param name="length">The number of bytes to write.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <returns>
-    /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
-    /// </returns>
-    public virtual async Task<(Error error, int transferLength)> WriteAsync(byte[] buffer, int offset, int length, int timeout) => 
-        await TransferAsync(buffer.AsMemory(offset, length), timeout).ConfigureAwait(false);
-    
-    /// <summary>
-    /// Writes data asynchronously to the current <see cref="UsbEndpointWriter"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer storing the data to write.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <returns>
-    /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
-    /// </returns>
     public virtual async Task<(Error error, int transferLength)> WriteAsync(Memory<byte> buffer, int timeout) => 
         await TransferAsync(buffer, timeout).ConfigureAwait(false);
 

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.Async.cs
@@ -28,7 +28,7 @@ public partial class UsbEndpointWriter
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
     public virtual async Task<(Error error, int transferLength)> WriteAsync(byte[] buffer, int offset, int length, int timeout) => 
-        await TransferAsync(buffer, offset, length, timeout).ConfigureAwait(false);
+        await TransferAsync(buffer.AsMemory(offset, length), timeout).ConfigureAwait(false);
     
     /// <summary>
     /// Writes data asynchronously to the current <see cref="UsbEndpointWriter"/>.
@@ -39,7 +39,7 @@ public partial class UsbEndpointWriter
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
     public virtual async Task<(Error error, int transferLength)> WriteAsync(Memory<byte> buffer, int timeout) => 
-        await WriteAsync(buffer, 0, buffer.Length, timeout).ConfigureAwait(false);
+        await TransferAsync(buffer, timeout).ConfigureAwait(false);
 
     /// <summary>
     /// Writes data asynchronously to the current <see cref="UsbEndpointWriter"/>.
@@ -52,5 +52,5 @@ public partial class UsbEndpointWriter
     /// Tuple of (<see cref="Error"/> error, <see cref="int"/> transferLength). error is <see cref="Error.Success"/> on success.
     /// </returns>
     public virtual async Task<(Error error, int transferLength)> WriteAsync(Memory<byte> buffer, int offset, int length, int timeout) => 
-        await TransferAsync(buffer, offset, length, timeout).ConfigureAwait(false);
+        await TransferAsync(buffer.Slice(offset, length), timeout).ConfigureAwait(false);
 }

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
@@ -58,7 +58,7 @@ public partial class UsbEndpointWriter : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Write(byte[] buffer, int offset, int count, int timeout, out int transferLength) => 
-        Transfer(buffer, offset, count, timeout, out transferLength);
+        Transfer(buffer.AsSpan(offset, count), timeout, out transferLength);
 
     /// <summary>
     /// Writes data to the current <see cref="UsbEndpointWriter"/>.
@@ -70,7 +70,7 @@ public partial class UsbEndpointWriter : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Write(Span<byte> buffer, int timeout, out int transferLength) => 
-        Write(buffer, 0, buffer.Length, timeout, out transferLength);
+        Transfer(buffer, timeout, out transferLength);
 
     /// <summary>
     /// Writes data to the current <see cref="UsbEndpointWriter"/>.
@@ -84,5 +84,5 @@ public partial class UsbEndpointWriter : UsbEndpointBase
     /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
     /// </returns>
     public virtual Error Write(Span<byte> buffer, int offset, int count, int timeout, out int transferLength) => 
-        Transfer(buffer, offset, count, timeout, out transferLength);
+        Transfer(buffer.Slice(offset, count), timeout, out transferLength);
 }

--- a/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
+++ b/src/LibUsbDotNet/LibUsb/UsbEndpointWriter.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace LibUsbDotNet.LibUsb;
 
-/// <summary>Contains methods for writing data to a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Write(byte[],int,out int)"/> functions.
+/// <summary>Contains methods for writing data to a <see cref="EndpointType.Bulk"/> or <see cref="EndpointType.Interrupt"/> endpoint using the overloaded <see cref="Write(Span{byte},int,out int)"/> functions.
 /// </summary>
 public partial class UsbEndpointWriter : UsbEndpointBase
 {
@@ -33,32 +33,6 @@ public partial class UsbEndpointWriter : UsbEndpointBase
         : base(usbDevice, alternateInterfaceID, (byte)writeEndpointID, endpointType)
     {
     }
-
-    /// <summary>
-    /// Writes data to the current <see cref="UsbEndpointWriter"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer storing the data to write.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <param name="transferLength">Number of bytes actually transferred.</param>
-    /// <returns>
-    /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
-    /// </returns>
-    public virtual Error Write(byte[] buffer, int timeout, out int transferLength) 
-        => Write(buffer, 0, buffer.Length, timeout, out transferLength);
-
-    /// <summary>
-    /// Writes data to the current <see cref="UsbEndpointWriter"/>.
-    /// </summary>
-    /// <param name="buffer">The buffer storing the data to write.</param>
-    /// <param name="offset">The position in buffer to start writing the data from.</param>
-    /// <param name="count">The number of bytes to write.</param>
-    /// <param name="timeout">Maximum time to wait for the transfer to complete.  If the transfer times out, the IO operation will be cancelled.</param>
-    /// <param name="transferLength">Number of bytes actually transferred.</param>
-    /// <returns>
-    /// <see cref="Error"/>.<see cref="Error.Success"/> on success.
-    /// </returns>
-    public virtual Error Write(byte[] buffer, int offset, int count, int timeout, out int transferLength) => 
-        Transfer(buffer.AsSpan(offset, count), timeout, out transferLength);
 
     /// <summary>
     /// Writes data to the current <see cref="UsbEndpointWriter"/>.


### PR DESCRIPTION
This PR fixes a safety issue in transfer methods by using `Span<byte>` / `Memory<byte>` consistently and removing raw `offset`/`length` pointer arithmetic from native transfer calls.

### Background
`UsbEndpointBase.Transfer` currently accepts a buffer pointer plus separate `offset` and `length` values.

When callers pass a `byte[]` or `Span<byte>` with an offset, the implementation adjusts the native buffer pointer manually and forwarded the raw length to native library.
This could lead to out-of-range native memory access if the offset/length combination exceeded the original array bounds.

https://github.com/LibUsbDotNet/LibUsbDotNet/blob/26ac4d04fe62a967ecd8b87f71433aadb1888bd8/src/LibUsbDotNet/LibUsb/UsbEndpointBase.cs#L107-L124

### Problem and repro code
The unsafe path looks like this:

```csharp
UsbEndpointWriter writer = ...;
byte[] buffer = new byte[64];

// Request 64 bytes starting from offset 1
writer.Write(buffer, 1, 64, 100, out var transferLength);
```

Because the internal transfer code calculated:
- pointer = &MemoryMarshal.GetReference(buffer) + offset
- length = 64

it would potentially access one byte past the end of `buffer`, causing a memory overrun.

### Proposed changes
In this PR,
- Updates `UsbEndpointReader` / `UsbEndpointWriter` sync and async methods to convert `byte[]` offset/length calls into `Span<byte>` / `Memory<byte>` slices via `AsSpan(offset, count)` and `AsMemory(offset, length)`.
- Simplifies `UsbEndpointBase.Transfer` and `AsyncTransfer.TransferAsync` to accept only `Span<byte>` / `Memory<byte>`.
- Removes unsafe pointer offset arithmetic before calling `NativeMethods.BulkTransfer` / `NativeMethods.InterruptTransfer`.
- Updates `AsyncTransfer.TransferAsync` usage to pass `Memory<byte>` directly.

This change ensures buffer slices are bounds-checked by `Span`/`Memory`, preventing unintended native memory access from invalid offset/length combinations.

**Update:**

In addition, this PR removes the following overloads that accept `byte[]` as parameters.  
Since `Span<T>` / `Memory<T>` support has already been introduced and implicit conversions from arrays are available in recent C# versions, these overloads are no longer necessary.

During the discussion leading to this change, several factors were considered:  
although removing these overloads breaks API compatibility, other breaking changes already exist in v3, while source‑level compatibility is preserved because calls will redirect to the `Span<T>` / `Memory<T>` overloads when applications are rebuilt.

```csharp
class UsbEndpointReader {
    public virtual Error Read(byte[] buffer, int timeout, out int transferLength);
    public virtual Error Read(byte[] buffer, int offset, int count, int timeout, out int transferLength);
    public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int timeout);
    public virtual async Task<(Error error, int transferLength)> ReadAsync(byte[] buffer, int offset, int length, int timeout);
}

class UsbEndpointWriter {
    public virtual Error Write(byte[] buffer, int timeout, out int transferLength);
    public virtual Error Write(byte[] buffer, int offset, int count, int timeout, out int transferLength);
    public virtual async Task<(Error error, int transferLength)> WriteAsync(byte[] buffer, int timeout);
    public virtual async Task<(Error error, int transferLength)> WriteAsync(byte[] buffer, int offset, int length, int timeout);
}
```