### PR TITLE
Examples: Add SPDX copyright and license headers

### DIFF
--- a/src/Examples/Hotplug/Program.cs
+++ b/src/Examples/Hotplug/Program.cs
@@ -1,4 +1,8 @@
-﻿using LibUsbDotNet;
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+using LibUsbDotNet;
 using LibUsbDotNet.Info;
 using LibUsbDotNet.LibUsb;
 using LibUsbDotNet.Main;

--- a/src/Examples/Read.Only/ReadOnly.cs
+++ b/src/Examples/Read.Only/ReadOnly.cs
@@ -1,4 +1,8 @@
-﻿using LibUsbDotNet;
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+using LibUsbDotNet;
 using LibUsbDotNet.LibUsb;
 using LibUsbDotNet.Main;
 using System;

--- a/src/Examples/Read.TransferQueue/Program.cs
+++ b/src/Examples/Read.TransferQueue/Program.cs
@@ -1,4 +1,8 @@
-﻿using LibUsbDotNet.LibUsb;
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+using LibUsbDotNet.LibUsb;
 using LibUsbDotNet.Main;
 using System;
 using System.IO;

--- a/src/Examples/Read.Write.Async/ReadWriteAsync.cs
+++ b/src/Examples/Read.Write.Async/ReadWriteAsync.cs
@@ -1,4 +1,8 @@
-﻿using LibUsbDotNet;
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+using LibUsbDotNet;
 using LibUsbDotNet.LibUsb;
 using LibUsbDotNet.Main;
 using System;

--- a/src/Examples/Read.Write/ReadWrite.cs
+++ b/src/Examples/Read.Write/ReadWrite.cs
@@ -1,4 +1,8 @@
-﻿using LibUsbDotNet;
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+using LibUsbDotNet;
 using LibUsbDotNet.LibUsb;
 using LibUsbDotNet.Main;
 using System.Linq;

--- a/src/Examples/Show.Info/ShowInfo.cs
+++ b/src/Examples/Show.Info/ShowInfo.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2006-2010 Travis Robinson
+// SPDX-FileCopyrightText: 2011-2023 LibUsbDotNet contributors
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
 using LibUsbDotNet.Info;
 using LibUsbDotNet.LibUsb;
 using System;


### PR DESCRIPTION
This is a series of PRs that will progressively convert header comments to SPDX format.